### PR TITLE
fix open.mp native component registration instructions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,9 +99,9 @@ jobs:
           ### Compatibility
           The binaries are **universal**: they run on SA-MP and on Open Multiplayer, on Linux and Windows alike.
 
-          - **SA-MP**: register under \`plugins=\` in \`server.cfg\`.
-          - **Open Multiplayer (native mode, recommended)**: register as a component under \`components\` in \`config.json\`. Loaded via \`ComponentEntryPoint\`, with access to \`ICore\`, \`ITimersComponent\` and the remaining native APIs.
-          - **Open Multiplayer (legacy mode)**: still supported — register under \`legacy_plugins\` (or the equivalent key in your \`config.json\`) if you prefer the SA-MP compat path over the native component. Same binary, no extra build flags.
+          - **SA-MP**: drop the binary into \`plugins/\` and register it under \`plugins=\` in \`server.cfg\`.
+          - **Open Multiplayer (native mode, recommended)**: drop the binary into the server's \`components/\` folder. It is loaded automatically via \`ComponentEntryPoint\`, with access to \`ICore\`, \`ITimersComponent\` and the remaining native APIs. No \`config.json\` entry is required.
+          - **Open Multiplayer (legacy mode)**: drop the binary into \`plugins/\` and declare it under \`pawn.legacy_plugins\` in \`config.json\`. Same binary, no extra build flags.
           EOF
 
           if [ -n "${CHANGELOG_SECTION}" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Built on top of [rust-samp v3.0.0](https://github.com/NullSablex/rust-samp/relea
 
 ### Added
 
-- **Universal binary.** A single artifact runs on SA-MP and on Open Multiplayer. Open Multiplayer can load it as a native component (registered under `components` in `config.json`) or in legacy mode (registered under `legacy_plugins`).
+- **Universal binary.** A single artifact runs on SA-MP and on Open Multiplayer. Open Multiplayer auto-loads it as a native component when dropped into the `components/` folder (no `config.json` entry needed — the folder itself is the registration), or in legacy mode when dropped into `plugins/` and declared under `pawn.legacy_plugins` in `config.json`.
 - `mysql_tick()` — drains the dispatch queue manually. Kept for backwards compatibility only; with rust-samp v3 the unified `on_tick` callback already pumps the queue on both SA-MP (`ProcessTick`) and Open Multiplayer (`ITimersComponent`, 5 ms by default).
 - `MYSQL_SAMP_VERSION` constant in `mysql_samp.inc` — string with the plugin version, auto-generated from `CARGO_PKG_VERSION` by `build.rs`.
 - `on_component_free` lifecycle hook — emits a single informational log line when any neighbouring Open Multiplayer component is released. Useful when correlating "mysql_samp misbehaved after plugin X was unloaded" reports.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,26 @@
+## mysql_samp v1.1.1
+
+Patch release. One fix: TLS connections actually work now.
+
+### Fixed
+
+- **`MYSQL_OPT_SSL` and `MYSQL_OPT_SSL_CA` are wired through to the connection builder.** Up to v1.1.0 both options were accepted by `mysql_options_set_int` / `mysql_options_set_str` but ignored on connect — every connection was plaintext, even when SSL was requested. From v1.1.1 on:
+  - With `MYSQL_OPT_SSL` set to `true`, `mysql_connect` configures `SslOpts::default()` on the pool (rustls, via the `default-rust` feature of the `mysql` crate).
+  - With `MYSQL_OPT_SSL_CA` also set, its path is passed to `with_root_cert_path`. Both `.pem` and `.der` are accepted.
+  - Without `MYSQL_OPT_SSL_CA`, the platform's default trust store is used.
+
+No Pawn API change. Existing scripts that already called `mysql_options_set_int(opts, MYSQL_OPT_SSL, 1)` start getting real TLS without any code edit — verify your CA path and server certificate before deploying.
+
+### Artifacts
+
+| File | Platform |
+|---|---|
+| `mysql_samp.so` | Linux i686 (`i686-unknown-linux-gnu`) |
+| `mysql_samp.dll` | Windows i686 (`i686-pc-windows-msvc`) |
+| `mysql_samp.inc` | Pawn include — identical file for SA-MP and Open Multiplayer |
+
+The Pawn version constant in `mysql_samp.inc` is regenerated automatically from `Cargo.toml` on every build.
+
+### Full changelog
+
+See [`CHANGELOG.md`](https://github.com/NullSablex/mysql_samp/blob/master/CHANGELOG.md). Diff vs the previous release: [v1.1.0 → v1.1.1](https://github.com/NullSablex/mysql_samp/compare/v1.1.0...v1.1.1).


### PR DESCRIPTION
Native components are auto-discovered from the components/ folder — no config.json entry is required. Only legacy plugins need an explicit declaration under pawn.legacy_plugins. Updates the release notes template in .github/workflows/release.yml and the 1.1.0 entry in CHANGELOG.md.