### PR TITLE
ci: migrate CodeQL from default to advanced setup

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,55 @@
+# CodeQL advanced setup.
+#
+# Replaces the repository's CodeQL *default* setup, which only analyses a pull
+# request when it touches files relevant to the configured languages. A PR that
+# changes only docs or dependency manifests produced no analysis at all, while
+# `master` still carried one per language — so the `code_scanning` branch rule
+# could not diff the two sides and reported "configurations not found".
+#
+# Running here, with no path filter, guarantees both configurations exist on
+# every pull request. The categories below must keep matching the ones recorded
+# on `master` (`/language:actions`, `/language:rust`) for that diff to work.
+name: CodeQL
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    # Weekly, to catch newly published queries against unchanged code.
+    - cron: '27 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write   # upload the SARIF results
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # Keep in sync with the languages the previous default setup covered.
+        language: [ actions, rust ]
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        with:
+          languages: ${{ matrix.language }}
+          # Neither language needs a compiled build for CodeQL to extract it.
+          build-mode: none
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Replaces the CodeQL default setup, which only analysed a pull request when it touched files relevant to the configured languages. A PR changing only docs or a dependency manifest produced no analysis at all, while master still carried one per language, so the code_scanning branch rule could not diff the two sides and reported 'configurations not found'.

The advanced setup has no path filter, so both /language:actions and /language:rust configurations exist on every PR, with categories matching what is already recorded on master. The default setup has already been disabled via the API - the two are mutually exclusive.