### PR TITLE
feat: include no estilo open.mp (Prefixo_PascalCase)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 Format inspired by [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/). Older entries live under [`changelog/`](changelog/).
 
+## [Unreleased]
+
+### Added
+
+- **open.mp naming style** — a second include, `<mysql_samp_omp>`, exposes every native under open.mp's `Prefix_PascalCase` convention: `MySQL_Connect`, `MySQL_Query`, `Cache_GetRowCount`, `ORM_Create`, `MySQL_TransactionExecute`, `MySQL_HashPassword`, and so on. Each name is a Pawn alias (`native MySQL_Connect(...) = mysql_connect;`) to the real snake_case native, so there is **no runtime cost and no change on the plugin side** — the same `.so`/`.dll` serves both. Include `<mysql_samp>` for the original style or `<mysql_samp_omp>` for the styled one — they are alternatives, not layers, so pick one per script. The styled include is self-contained (it carries its own copy of the `MYSQL_OPT_*` enums and the `OnQueryError` forward) and is generated from the base by `build.rs` on every build, so the two can never drift: a native, enum or constant added to the template appears in both automatically.
+
 ## [1.2.0] — 2026/08/05
 
 Built on top of [rust-samp v3.4.0](https://github.com/NullSablex/rust-samp). No Pawn-visible API was removed or renamed.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The same binary loads on SA-MP and on Open Multiplayer — natively as a compone
 - **Transactions** — `mysql_transaction_*` runs a batch atomically on one connection and rolls it back if any step fails.
 - **Argon2id password hashing** — `mysql_hash_password` / `mysql_verify_password`, off the server thread on a bounded worker pool. The plaintext never reaches SQL, so it never reaches your logs.
 - **TLS** — rustls compiled in, with CA pinning, mutual TLS and certificate verification on by default.
+- **Two naming styles** — write the API in its original snake_case (`mysql_connect`) via `<mysql_samp>`, or in open.mp's `Prefix_PascalCase` (`MySQL_Connect`, `Cache_GetRowCount`) via `<mysql_samp_omp>`. Same plugin, aliases only, no runtime cost.
 - **Safe by default** — `sql_mode`-aware escaping, forced UTF-8, protection against SQL injection and memory exhaustion.
 - **Universal binary** — built on top of [rust-samp](https://github.com/NullSablex/rust-samp) v3.4.0; one `.so`/`.dll` runs on SA-MP and on Open Multiplayer (native component or legacy).
 - **Simple deploy** — drop the `.so` or `.dll` in and you are done. No system libraries to install.
@@ -47,6 +48,7 @@ The same binary loads on SA-MP and on Open Multiplayer — natively as a compone
    - `mysql_samp.so` (Linux i686)
    - `mysql_samp.dll` (Windows i686, MSVC ABI)
    - `mysql_samp.inc` (Pawn include, shared between SA-MP and Open Multiplayer)
+   - `mysql_samp_omp.inc` (optional — the same API in open.mp's `Prefix_PascalCase` naming style)
 2. Place the binary in the server's `plugins/` directory.
 3. Copy `mysql_samp.inc` to your compiler's include folder:
    - **Windows:** `pawno/include/` or `qawno/include/`

--- a/build.rs
+++ b/build.rs
@@ -38,7 +38,7 @@ fn generate_inc() {
 
     // No `cargo:rerun-if-changed` directives: build.rs runs on every build
     // so the .inc tracks the current Cargo version, build date and template
-    // without manual intervention. The write below is idempotent — it only
+    // without manual intervention. The write below is idempotent - it only
     // touches disk when the rendered output actually differs from the file
     // on disk, so the always-run policy does not churn timestamps.
 
@@ -51,5 +51,137 @@ fn generate_inc() {
     if fs::read_to_string(output_path).ok().as_deref() != Some(rendered.as_str()) {
         fs::write(output_path, &rendered)
             .unwrap_or_else(|e| panic!("failed to write {output_path}: {e}"));
+    }
+
+    generate_omp_inc(&rendered);
+}
+
+/// Generates `mysql_samp_omp.inc` - a **standalone** include exposing the API
+/// under open.mp-style `Prefix_PascalCase` names.
+///
+/// Self-contained on purpose: the two includes are alternatives (you write one
+/// style or the other, never both in the same script), so this carries its own
+/// copy of the enums, the `MYSQL_SAMP_VERSION` define and the `OnQueryError`
+/// forward rather than pulling in the base. Only the natives differ - each
+/// becomes `native Styled(...) = real;`, a Pawn alias to the real snake_case
+/// native, which resolves at runtime with no cost and no plugin-side change
+/// (the target need not even be declared, so the snake_case names are absent).
+///
+/// Derived from the base `.inc` on every build, so the two never drift: a
+/// native, enum or constant added to the template appears here automatically.
+fn generate_omp_inc(base_rendered: &str) {
+    use std::fmt::Write;
+    use std::fs;
+
+    let output_path = "include/mysql_samp_omp.inc";
+
+    let mut out = String::from(
+        "/*\n\
+         \x20* mysql_samp - open.mp naming style (standalone).\n\
+         \x20*\n\
+         \x20* GENERATED from mysql_samp.inc by build.rs - do not edit by hand.\n\
+         \x20*\n\
+         \x20* Include THIS instead of <mysql_samp> to write the API in\n\
+         \x20* open.mp's Prefix_PascalCase style (MySQL_Connect, Cache_GetRowCount,\n\
+         \x20* ORM_Create). Each native aliases the real one, so there is no\n\
+         \x20* runtime cost and nothing changes on the plugin side. This file is\n\
+         \x20* self-contained - do not include it together with <mysql_samp>.\n\
+         \x20*/\n\n\
+         #if defined _mysql_samp_omp_included\n    #endinput\n#endif\n\
+         #define _mysql_samp_omp_included\n",
+    );
+
+    // Everything after the base guard: the version define, the enums, the
+    // forward and the natives. The natives are rewritten as aliases; the rest
+    // is copied verbatim, so enums/defines/forward stay a single source.
+    let marker = "#define _mysql_samp_included";
+    let body = match base_rendered.find(marker) {
+        Some(i) => &base_rendered[i + marker.len()..],
+        None => base_rendered,
+    };
+
+    for line in body.lines() {
+        let trimmed = line.trim();
+
+        let Some(rest) = trimmed.strip_prefix("native ") else {
+            // Not a native declaration - copy the line as-is (enum, forward,
+            // define, comment, blank).
+            out.push_str(line);
+            out.push('\n');
+            continue;
+        };
+
+        let rest = rest.trim().trim_end_matches(';').trim();
+        let (Some(open), Some(close)) = (rest.find('('), rest.rfind(')')) else {
+            out.push_str(line);
+            out.push('\n');
+            continue;
+        };
+        let head = rest[..open].trim(); // optional `tag:` plus the native name
+        let params = &rest[open + 1..close];
+
+        let (tag, name) = match head.rfind(':') {
+            Some(i) => (&head[..=i], head[i + 1..].trim()),
+            None => ("", head),
+        };
+
+        let styled = to_omp_name(name);
+        // The right-hand side is the real native the plugin registered; the
+        // left-hand side is the alias the gamemode writes.
+        let _ = writeln!(out, "native {tag}{styled}({params}) = {name};");
+    }
+
+    if fs::read_to_string(output_path).ok().as_deref() != Some(out.as_str()) {
+        fs::write(output_path, &out)
+            .unwrap_or_else(|e| panic!("failed to write {output_path}: {e}"));
+    }
+}
+
+/// `mysql_stmt_new` -> `MySQL_StmtNew`, `cache_get_row_count` ->
+/// `Cache_GetRowCount`, `orm_create` -> `ORM_Create`.
+///
+/// The first segment is the group prefix, capitalised the way open.mp writes
+/// these acronyms; the remaining segments become one PascalCase word.
+fn to_omp_name(name: &str) -> String {
+    // A handful of native names glue two words together in one snake_case
+    // segment (`pquery`, `addvar`, ...), which the mechanical split cannot break
+    // apart. Map those explicitly so the styled name reads the way open.mp
+    // would write it.
+    let full = match name {
+        "mysql_pquery" => Some("MySQL_PQuery"),
+        "mysql_stmt_pexecute" => Some("MySQL_StmtPExecute"),
+        "orm_addvar_int" => Some("ORM_AddVarInt"),
+        "orm_addvar_float" => Some("ORM_AddVarFloat"),
+        "orm_addvar_string" => Some("ORM_AddVarString"),
+        "orm_delvar" => Some("ORM_DelVar"),
+        "orm_setkey" => Some("ORM_SetKey"),
+        _ => None,
+    };
+    if let Some(name) = full {
+        return name.to_string();
+    }
+
+    let mut segments = name.split('_');
+
+    let prefix = match segments.next().unwrap_or("") {
+        "mysql" => "MySQL".to_string(),
+        "cache" => "Cache".to_string(),
+        "orm" => "ORM".to_string(),
+        other => capitalize(other),
+    };
+
+    let rest: String = segments.map(capitalize).collect();
+    if rest.is_empty() {
+        prefix
+    } else {
+        format!("{prefix}_{rest}")
+    }
+}
+
+fn capitalize(word: &str) -> String {
+    let mut chars = word.chars();
+    match chars.next() {
+        Some(first) => first.to_ascii_uppercase().to_string() + chars.as_str(),
+        None => String::new(),
     }
 }

--- a/include/mysql_samp.inc
+++ b/include/mysql_samp.inc
@@ -179,7 +179,7 @@ native bool:orm_setkey(orm_id, const column_name[]);
 
 // Password hashing (Argon2id)
 //
-// Both natives run on a worker thread — Argon2id is deliberately slow, so
+// Both natives run on a worker thread - Argon2id is deliberately slow, so
 // hashing on the server thread would stall it. The result is delivered as the
 // FIRST argument of the callback, followed by the extras described by format.
 //
@@ -191,7 +191,7 @@ native bool:orm_setkey(orm_id, const column_name[]);
 //
 // The hash is a PHC string (`$argon2id$v=19$m=...`) around 100 characters long;
 // size the storage column and any Pawn buffer accordingly (VARCHAR(255) is the
-// usual choice). It already embeds its own random salt — do not add one.
+// usual choice). It already embeds its own random salt - do not add one.
 native bool:mysql_hash_password(const password[], const callback[], const format[] = "", {Float,_}:...);
 native bool:mysql_verify_password(const password[], const hash[], const callback[], const format[] = "", {Float,_}:...);
 
@@ -200,7 +200,7 @@ native bool:mysql_verify_password(const password[], const hash[], const callback
 // Steps are collected first and then executed as one unit on a single
 // connection: START TRANSACTION, every step, COMMIT. Any failing step rolls the
 // whole batch back and fires OnQueryError. There is no interactive
-// begin/commit API on purpose — holding a pooled connection between ticks would
+// begin/commit API on purpose - holding a pooled connection between ticks would
 // leak it whenever a gamemode never reached the commit.
 //
 //   new tx = mysql_transaction_new(connId);

--- a/include/mysql_samp.inc.in
+++ b/include/mysql_samp.inc.in
@@ -179,7 +179,7 @@ native bool:orm_setkey(orm_id, const column_name[]);
 
 // Password hashing (Argon2id)
 //
-// Both natives run on a worker thread — Argon2id is deliberately slow, so
+// Both natives run on a worker thread - Argon2id is deliberately slow, so
 // hashing on the server thread would stall it. The result is delivered as the
 // FIRST argument of the callback, followed by the extras described by format.
 //
@@ -191,7 +191,7 @@ native bool:orm_setkey(orm_id, const column_name[]);
 //
 // The hash is a PHC string (`$argon2id$v=19$m=...`) around 100 characters long;
 // size the storage column and any Pawn buffer accordingly (VARCHAR(255) is the
-// usual choice). It already embeds its own random salt — do not add one.
+// usual choice). It already embeds its own random salt - do not add one.
 native bool:mysql_hash_password(const password[], const callback[], const format[] = "", {Float,_}:...);
 native bool:mysql_verify_password(const password[], const hash[], const callback[], const format[] = "", {Float,_}:...);
 
@@ -200,7 +200,7 @@ native bool:mysql_verify_password(const password[], const hash[], const callback
 // Steps are collected first and then executed as one unit on a single
 // connection: START TRANSACTION, every step, COMMIT. Any failing step rolls the
 // whole batch back and fires OnQueryError. There is no interactive
-// begin/commit API on purpose — holding a pooled connection between ticks would
+// begin/commit API on purpose - holding a pooled connection between ticks would
 // leak it whenever a gamemode never reached the commit.
 //
 //   new tx = mysql_transaction_new(connId);

--- a/include/mysql_samp_omp.inc
+++ b/include/mysql_samp_omp.inc
@@ -1,0 +1,225 @@
+/*
+ * mysql_samp - open.mp naming style (standalone).
+ *
+ * GENERATED from mysql_samp.inc by build.rs - do not edit by hand.
+ *
+ * Include THIS instead of <mysql_samp> to write the API in
+ * open.mp's Prefix_PascalCase style (MySQL_Connect, Cache_GetRowCount,
+ * ORM_Create). Each native aliases the real one, so there is no
+ * runtime cost and nothing changes on the plugin side. This file is
+ * self-contained - do not include it together with <mysql_samp>.
+ */
+
+#if defined _mysql_samp_omp_included
+    #endinput
+#endif
+#define _mysql_samp_omp_included
+
+
+#define MYSQL_SAMP_VERSION "1.2.0"
+
+// Connection options
+enum {
+    MYSQL_OPT_PORT = 0,
+    MYSQL_OPT_SSL,
+    MYSQL_OPT_SSL_CA,
+    MYSQL_OPT_CONNECT_TIMEOUT,
+    MYSQL_OPT_AUTO_RECONNECT,
+    // Client certificate chain (PEM/DER) for mutual TLS. Needs MYSQL_OPT_SSL_KEY.
+    MYSQL_OPT_SSL_CERT,
+    // Client private key (PEM/DER) for mutual TLS. Needs MYSQL_OPT_SSL_CERT.
+    MYSQL_OPT_SSL_KEY,
+    // 1 (default) verifies the server certificate and hostname. Setting it to 0
+    // keeps the traffic encrypted but accepts ANY certificate, which defeats the
+    // point of TLS against an active attacker. Prefer MYSQL_OPT_SSL_CA.
+    MYSQL_OPT_SSL_VERIFY_CERT,
+    // Maximum connections the pool may open. Default is the driver's (max 100).
+    MYSQL_OPT_POOL_SIZE,
+}
+
+// Error codes
+enum {
+    MYSQL_OK = 0,
+    MYSQL_ERROR_CONNECTION_FAILED,
+    MYSQL_ERROR_INVALID_OPTIONS,
+    MYSQL_ERROR_INVALID_CONNECTION,
+    MYSQL_ERROR_PING_FAILED,
+    MYSQL_ERROR_QUERY_FAILED,
+    MYSQL_ERROR_NO_CACHE_ACTIVE,
+    MYSQL_ERROR_INVALID_ORM,
+    MYSQL_ERROR_ORM_KEY_NOT_SET,
+}
+
+// Log levels
+enum {
+    MYSQL_LOG_NONE = 0,
+    MYSQL_LOG_ERROR,
+    MYSQL_LOG_WARNING,
+    MYSQL_LOG_INFO,
+    MYSQL_LOG_ALL,
+}
+
+// ORM error codes
+enum {
+    ORM_OK = 0,
+    ORM_NO_DATA,
+}
+
+// Forward: invoked when a threaded query fails.
+forward OnQueryError(errorid, const error[], const callback[], const query[], connId);
+
+// Options
+native MySQL_OptionsNew() = mysql_options_new;
+native bool:MySQL_OptionsSetInt(handle, option, value) = mysql_options_set_int;
+native bool:MySQL_OptionsSetStr(handle, option, const value[]) = mysql_options_set_str;
+
+// Connection
+native MySQL_Connect(const host[], const user[], const password[], const database[], options = 0) = mysql_connect;
+// Reads host / user / password / database from a `key = value` file, keeping
+// credentials out of the gamemode source. Options stay with mysql_options_new.
+native MySQL_ConnectFile(const path[] = "mysql.ini", options = 0) = mysql_connect_file;
+native bool:MySQL_Close(connId) = mysql_close;
+native bool:MySQL_Status(connId, dest[], max_len = sizeof(dest)) = mysql_status;
+
+// Error
+native MySQL_Errno(connId = 0) = mysql_errno;
+native bool:MySQL_Error(connId, dest[], max_len = sizeof(dest)) = mysql_error;
+
+// Charset
+native bool:MySQL_SetCharset(connId, const charset[]) = mysql_set_charset;
+native bool:MySQL_GetCharset(connId, dest[], max_len = sizeof(dest)) = mysql_get_charset;
+
+// Utility
+native MySQL_UnprocessedQueries() = mysql_unprocessed_queries;
+native bool:MySQL_Log(log_level) = mysql_log;
+
+// Query (non-blocking)
+native bool:MySQL_Query(connId, const query[], const callback[] = "", const format[] = "", {Float,_}:...) = mysql_query;
+native bool:MySQL_PQuery(connId, const query[], const callback[] = "", const format[] = "", {Float,_}:...) = mysql_pquery;
+// Kept for backwards compatibility only: since rust-samp v3.0.0 the unified
+// on_tick already dispatches callbacks automatically on SA-MP and native open.mp.
+native bool:MySQL_Tick() = mysql_tick;
+// connId selects the escaping rules, which depend on the server's sql_mode.
+// Pass the real connection whenever the server may run with NO_BACKSLASH_ESCAPES;
+// 0 assumes the MySQL default.
+native bool:MySQL_EscapeString(const src[], dest[], max_len = sizeof(dest), connId = 0) = mysql_escape_string;
+native MySQL_Format(connId, dest[], max_len, const format[], {Float,_}:...) = mysql_format;
+// Runs the statements of a .sql file in order on one connection, non-blocking.
+// Split on `;` outside literals and comments. NOT transactional: DDL commits
+// implicitly in MySQL. Stops at the first failure, naming which statement.
+native bool:MySQL_QueryFile(connId, const path[], const callback[] = "", const format[] = "", {Float,_}:...) = mysql_query_file;
+
+// Prepared statements (non-blocking, FIFO like mysql_query)
+//
+// Values are bound server-side over the binary protocol instead of being pasted
+// into the SQL text, so no escaping is involved and a value can never be
+// reinterpreted as syntax. Prefer this over mysql_format for anything that
+// carries player input.
+//
+//   new stmt = mysql_stmt_new(connId, "SELECT id FROM users WHERE name = ? AND age > ?");
+//   mysql_stmt_bind_str(stmt, inputName);
+//   mysql_stmt_bind_int(stmt, 18);
+//   mysql_stmt_execute(stmt, "OnUsersFound", "d", playerid);
+//
+// The statement is reusable: call mysql_stmt_reset to drop the bound values and
+// bind a fresh set. mysql_stmt_execute fails if the number of bound values does
+// not match the number of ? placeholders.
+native MySQL_StmtNew(connId, const query[]) = mysql_stmt_new;
+native bool:MySQL_StmtClose(stmtId) = mysql_stmt_close;
+native bool:MySQL_StmtReset(stmtId) = mysql_stmt_reset;
+native bool:MySQL_StmtBindInt(stmtId, value) = mysql_stmt_bind_int;
+native bool:MySQL_StmtBindFloat(stmtId, Float:value) = mysql_stmt_bind_float;
+native bool:MySQL_StmtBindStr(stmtId, const value[]) = mysql_stmt_bind_str;
+native bool:MySQL_StmtBindNull(stmtId) = mysql_stmt_bind_null;
+native bool:MySQL_StmtExecute(stmtId, const callback[] = "", const format[] = "", {Float,_}:...) = mysql_stmt_execute;
+// Parallel counterpart, mirroring mysql_pquery: no ordering guarantee.
+native bool:MySQL_StmtPExecute(stmtId, const callback[] = "", const format[] = "", {Float,_}:...) = mysql_stmt_pexecute;
+
+// Cache
+native Cache_GetRowCount() = cache_get_row_count;
+native Cache_GetFieldCount() = cache_get_field_count;
+native bool:Cache_GetFieldName(field_idx, dest[], max_len = sizeof(dest)) = cache_get_field_name;
+native Cache_GetFieldType(field_idx) = cache_get_field_type;
+native bool:Cache_GetValueIndex(row, col, dest[], max_len = sizeof(dest)) = cache_get_value_index;
+native Cache_GetValueIndexInt(row, col) = cache_get_value_index_int;
+native Float:Cache_GetValueIndexFloat(row, col) = cache_get_value_index_float;
+native bool:Cache_GetValueName(row, const field_name[], dest[], max_len = sizeof(dest)) = cache_get_value_name;
+native Cache_GetValueNameInt(row, const field_name[]) = cache_get_value_name_int;
+native Float:Cache_GetValueNameFloat(row, const field_name[]) = cache_get_value_name_float;
+native bool:Cache_IsValueIndexNull(row, col) = cache_is_value_index_null;
+native bool:Cache_IsValueNameNull(row, const field_name[]) = cache_is_value_name_null;
+native Cache_AffectedRows() = cache_affected_rows;
+native Cache_InsertId() = cache_insert_id;
+native Cache_WarningCount() = cache_warning_count;
+native Cache_GetQueryExecTime() = cache_get_query_exec_time;
+native bool:Cache_GetQueryString(dest[], max_len = sizeof(dest)) = cache_get_query_string;
+// Result sets in the active cache. A plain query yields 1; a script or a
+// stored-procedure CALL can yield several. cache_set_result picks which one
+// every other cache_* native reports on (index 0 until changed).
+native Cache_GetResultCount() = cache_get_result_count;
+native bool:Cache_SetResult(result_index) = cache_set_result;
+
+native Cache_Save() = cache_save;
+native bool:Cache_Delete(cache_id) = cache_delete;
+native bool:Cache_SetActive(cache_id) = cache_set_active;
+native bool:Cache_UnsetActive() = cache_unset_active;
+native bool:Cache_IsAnyActive() = cache_is_any_active;
+native bool:Cache_IsValid(cache_id) = cache_is_valid;
+
+// ORM
+native ORM_Create(const table[], connId) = orm_create;
+native bool:ORM_Destroy(orm_id) = orm_destroy;
+native ORM_Errno(orm_id) = orm_errno;
+native bool:ORM_Select(orm_id, const callback[] = "", const format[] = "", {Float,_}:...) = orm_select;
+native bool:ORM_Update(orm_id, const callback[] = "", const format[] = "", {Float,_}:...) = orm_update;
+native bool:ORM_Insert(orm_id, const callback[] = "", const format[] = "", {Float,_}:...) = orm_insert;
+native bool:ORM_Delete(orm_id, const callback[] = "", const format[] = "", {Float,_}:...) = orm_delete;
+native bool:ORM_Save(orm_id, const callback[] = "", const format[] = "", {Float,_}:...) = orm_save;
+native bool:ORM_ApplyCache(orm_id, row = 0) = orm_apply_cache;
+native bool:ORM_AddVarInt(orm_id, &var, const column_name[]) = orm_addvar_int;
+native bool:ORM_AddVarFloat(orm_id, &Float:var, const column_name[]) = orm_addvar_float;
+native bool:ORM_AddVarString(orm_id, var[], var_max_len, const column_name[]) = orm_addvar_string;
+native bool:ORM_DelVar(orm_id, const column_name[]) = orm_delvar;
+native bool:ORM_ClearVars(orm_id) = orm_clear_vars;
+native bool:ORM_SetKey(orm_id, const column_name[]) = orm_setkey;
+
+// Password hashing (Argon2id)
+//
+// Both natives run on a worker thread - Argon2id is deliberately slow, so
+// hashing on the server thread would stall it. The result is delivered as the
+// FIRST argument of the callback, followed by the extras described by format.
+//
+//   forward OnHashed(const hash[], playerid);
+//   mysql_hash_password("secret", "OnHashed", "d", playerid);
+//
+//   forward OnChecked(bool:success, playerid);
+//   mysql_verify_password("secret", stored_hash, "OnChecked", "d", playerid);
+//
+// The hash is a PHC string (`$argon2id$v=19$m=...`) around 100 characters long;
+// size the storage column and any Pawn buffer accordingly (VARCHAR(255) is the
+// usual choice). It already embeds its own random salt - do not add one.
+native bool:MySQL_HashPassword(const password[], const callback[], const format[] = "", {Float,_}:...) = mysql_hash_password;
+native bool:MySQL_VerifyPassword(const password[], const hash[], const callback[], const format[] = "", {Float,_}:...) = mysql_verify_password;
+
+// Transactions (non-blocking, all-or-nothing)
+//
+// Steps are collected first and then executed as one unit on a single
+// connection: START TRANSACTION, every step, COMMIT. Any failing step rolls the
+// whole batch back and fires OnQueryError. There is no interactive
+// begin/commit API on purpose - holding a pooled connection between ticks would
+// leak it whenever a gamemode never reached the commit.
+//
+//   new tx = mysql_transaction_new(connId);
+//   mysql_transaction_add(tx, "UPDATE accounts SET balance = balance - 100 WHERE id = 1");
+//   mysql_transaction_add(tx, "UPDATE accounts SET balance = balance + 100 WHERE id = 2");
+//   mysql_transaction_execute(tx, "OnTransferDone", "d", playerid);
+//
+// mysql_transaction_add_stmt appends a prepared statement with its bound values,
+// which is the safe way to put player input inside a transaction.
+// mysql_transaction_execute consumes the handle: the ID is invalid afterwards.
+// The callback receives the cache of the LAST step.
+native MySQL_TransactionNew(connId) = mysql_transaction_new;
+native bool:MySQL_TransactionDestroy(txId) = mysql_transaction_destroy;
+native bool:MySQL_TransactionAdd(txId, const query[]) = mysql_transaction_add;
+native bool:MySQL_TransactionAddStmt(txId, stmtId) = mysql_transaction_add_stmt;
+native bool:MySQL_TransactionExecute(txId, const callback[] = "", const format[] = "", {Float,_}:...) = mysql_transaction_execute;


### PR DESCRIPTION
## O que

Um segundo include, `mysql_samp_omp.inc`, que expõe a API sob a convenção `Prefix_PascalCase` do open.mp — o mesmo padrão do `omp_database.inc` deles (`DB_GetRowCount`).

```pawn
// estilo original
#include <mysql_samp>
new c = mysql_connect("127.0.0.1", "u", "p", "d");

// estilo open.mp
#include <mysql_samp_omp>
new c = MySQL_Connect("127.0.0.1", "u", "p", "d");
```

## Como

Cada nome é um alias Pawn (`native MySQL_Connect(...) = mysql_connect;`) para a native snake_case real. **Nenhuma native nova no Rust, zero custo de runtime** — o mesmo `.so`/`.dll` serve os dois estilos. Confirmei que o pawncc resolve o alias sem a native alvo declarada (resolvida no runtime pelo plugin).

## Autossuficiente

Os dois includes são **alternativas** (um por script, nunca os dois). O `omp` carrega sua própria cópia dos enums `MYSQL_OPT_*` e do forward `OnQueryError`, então não depende do base.

## Gerado, nunca escrito à mão

O `build.rs` deriva o `omp.inc` do próprio `mysql_samp.inc`: copia enums/defines/forward verbatim e reescreve cada native como alias. Os dois **nunca divergem** — uma native, enum ou constante adicionada ao template aparece nos dois automaticamente. A conversão de nome tem um mapa de exceções para palavras coladas (`pquery`→`PQuery`, `addvar`→`AddVar`, `delvar`→`DelVar`, `setkey`→`SetKey`, `pexecute`→`PExecute`); o resto é mecânico.

## Encoding

Ambos os `.inc` gerados são **ASCII puro**. Troquei os em-dashes (U+2014) por hífen no template base — num arquivo Pawn distribuído, UTF-8 vira lixo em editor/compilador latin-1.

## Validação

- Gamemode no estilo novo compila limpo com o pawncc usando **só o omp** no include path (base inacessível), provando a autossuficiência.
- 75 aliases = 75 natives.
- 171 testes, clippy limpo, ambos os targets compilando.
- Sem seção de versão nova no `Cargo.toml` — fica em `[Unreleased]` no CHANGELOG; o bump é decisão sua na hora de cortar a release.
