### PR TITLE
chore: arquivos Pawn de exemplo/benchmark em ASCII puro

### DIFF
--- a/benchmark/bench_mysql_samp.pwn
+++ b/benchmark/bench_mysql_samp.pwn
@@ -81,7 +81,7 @@ public BenchStart()
     {
         new errMsg[256];
         mysql_error(gMysql, errMsg);
-        printf("[Bench] ERRO: conexao falhou — %s", errMsg);
+        printf("[Bench] ERRO: conexao falhou - %s", errMsg);
         print ("[Bench] Verifique host, usuario, senha e nome do banco.");
         return;
     }
@@ -91,7 +91,7 @@ public BenchStart()
 }
 
 // ============================================================
-// Etapa 1: SELECT sequencial (mysql_query — FIFO)
+// Etapa 1: SELECT sequencial (mysql_query - FIFO)
 // Simula o padrao mais comum: um jogador faz login,
 // aguarda o resultado antes do proximo.
 // ============================================================
@@ -101,7 +101,7 @@ stock BenchSelectFIFO()
     gDone  = 0;
     gStart = GetTickCount();
 
-    printf("[Bench] Etapa 1/%d — SELECT FIFO (mysql_query) x%d", 4, ROUNDS_SELECT);
+    printf("[Bench] Etapa 1/%d - SELECT FIFO (mysql_query) x%d", 4, ROUNDS_SELECT);
 
     for (new i = 1; i <= ROUNDS_SELECT; i++)
     {
@@ -139,7 +139,7 @@ stock BenchSelectParallel()
     gDone  = 0;
     gStart = GetTickCount();
 
-    printf("[Bench] Etapa 2/%d — SELECT paralelo (mysql_pquery) x%d", 4, ROUNDS_PSELECT);
+    printf("[Bench] Etapa 2/%d - SELECT paralelo (mysql_pquery) x%d", 4, ROUNDS_PSELECT);
 
     for (new i = 1; i <= ROUNDS_PSELECT; i++)
     {
@@ -176,7 +176,7 @@ stock BenchInsert()
     gDone  = 0;
     gStart = GetTickCount();
 
-    printf("[Bench] Etapa 3/%d — INSERT paralelo (mysql_pquery) x%d", 4, ROUNDS_INSERT);
+    printf("[Bench] Etapa 3/%d - INSERT paralelo (mysql_pquery) x%d", 4, ROUNDS_INSERT);
 
     new query[192];
     for (new i = 0; i < ROUNDS_INSERT; i++)
@@ -213,7 +213,7 @@ public OnBenchInsert(round)
 
 stock BenchFormat()
 {
-    printf("[Bench] Etapa 4/%d — mysql_format com escape x%d (sincrono)", 4, ROUNDS_FORMAT);
+    printf("[Bench] Etapa 4/%d - mysql_format com escape x%d (sincrono)", 4, ROUNDS_FORMAT);
 
     new query[256];
     new dangerous[] = "'; DROP TABLE bench_test; -- O'Brien & Co.";

--- a/benchmark/bench_r41.pwn
+++ b/benchmark/bench_r41.pwn
@@ -88,7 +88,7 @@ public BenchStart()
     {
         new errMsg[256];
         mysql_error(errMsg, sizeof(errMsg), gMysql);
-        printf("[Bench] ERRO: conexao falhou — %s", errMsg);
+        printf("[Bench] ERRO: conexao falhou - %s", errMsg);
         print ("[Bench] Verifique host, usuario, senha e nome do banco.");
         return;
     }
@@ -98,7 +98,7 @@ public BenchStart()
 }
 
 // ============================================================
-// Etapa 1: SELECT sequencial (mysql_tquery — FIFO)
+// Etapa 1: SELECT sequencial (mysql_tquery - FIFO)
 // Equivalente a mysql_query do mysql_samp.
 // ============================================================
 
@@ -107,7 +107,7 @@ stock BenchSelectFIFO()
     gDone  = 0;
     gStart = GetTickCount();
 
-    printf("[Bench] Etapa 1/%d — SELECT FIFO (mysql_tquery) x%d", 4, ROUNDS_SELECT);
+    printf("[Bench] Etapa 1/%d - SELECT FIFO (mysql_tquery) x%d", 4, ROUNDS_SELECT);
 
     for (new i = 1; i <= ROUNDS_SELECT; i++)
     {
@@ -144,7 +144,7 @@ stock BenchSelectParallel()
     gDone  = 0;
     gStart = GetTickCount();
 
-    printf("[Bench] Etapa 2/%d — SELECT paralelo (mysql_pquery) x%d", 4, ROUNDS_PSELECT);
+    printf("[Bench] Etapa 2/%d - SELECT paralelo (mysql_pquery) x%d", 4, ROUNDS_PSELECT);
 
     for (new i = 1; i <= ROUNDS_PSELECT; i++)
     {
@@ -181,7 +181,7 @@ stock BenchInsert()
     gDone  = 0;
     gStart = GetTickCount();
 
-    printf("[Bench] Etapa 3/%d — INSERT paralelo (mysql_pquery) x%d", 4, ROUNDS_INSERT);
+    printf("[Bench] Etapa 3/%d - INSERT paralelo (mysql_pquery) x%d", 4, ROUNDS_INSERT);
 
     new query[192];
     for (new i = 0; i < ROUNDS_INSERT; i++)
@@ -213,13 +213,13 @@ public OnBenchInsert(round)
 
 // ============================================================
 // Etapa 4: mysql_format com escape
-// No R41-4, %s NAO escapa — usamos %e para escapar,
+// No R41-4, %s NAO escapa - usamos %e para escapar,
 // que e o equivalente ao %s do mysql_samp.
 // ============================================================
 
 stock BenchFormat()
 {
-    printf("[Bench] Etapa 4/%d — mysql_format com escape x%d (sincrono)", 4, ROUNDS_FORMAT);
+    printf("[Bench] Etapa 4/%d - mysql_format com escape x%d (sincrono)", 4, ROUNDS_FORMAT);
 
     new query[256];
     new dangerous[] = "'; DROP TABLE bench_test; -- O'Brien & Co.";

--- a/examples/01_basic_connection.pwn
+++ b/examples/01_basic_connection.pwn
@@ -1,4 +1,4 @@
-// 01_basic_connection.pwn — open a connection at OnGameModeInit, close it on exit.
+// 01_basic_connection.pwn - open a connection at OnGameModeInit, close it on exit.
 //
 // Two variants are shown:
 //   1. The minimal call (default port 3306, no SSL, auto_reconnect on).

--- a/examples/02_threaded_query.pwn
+++ b/examples/02_threaded_query.pwn
@@ -1,8 +1,8 @@
-// 02_threaded_query.pwn — non-blocking SELECT with a callback, FIFO-ordered.
+// 02_threaded_query.pwn - non-blocking SELECT with a callback, FIFO-ordered.
 //
 // mysql_query() runs the query on a worker thread and dispatches the result
 // to the named callback. Inside the callback the result is the *active cache*
-// — read it with the cache_* natives. The cache is freed automatically when
+// - read it with the cache_* natives. The cache is freed automatically when
 // the callback returns (use cache_save() to keep it longer).
 //
 // Format spec for the variadic args: each letter maps to one extra param.

--- a/examples/03_parallel_query.pwn
+++ b/examples/03_parallel_query.pwn
@@ -1,4 +1,4 @@
-// 03_parallel_query.pwn — mysql_pquery: parallel, no ordering guarantee.
+// 03_parallel_query.pwn - mysql_pquery: parallel, no ordering guarantee.
 //
 // Use mysql_pquery when the result does NOT depend on a previously queued
 // query for the same row. Typical fit: independent UPDATEs, write-only logging,

--- a/examples/04_escape_and_format.pwn
+++ b/examples/04_escape_and_format.pwn
@@ -1,11 +1,11 @@
-// 04_escape_and_format.pwn — building queries safely.
+// 04_escape_and_format.pwn - building queries safely.
 //
 // mysql_format specifiers:
 //   %d  int
 //   %f  float
 //   %s  string, auto-escaped (preferred for user input)
 //   %e  alias of %s, explicit "escape"
-//   %r  string, raw (NO escape) — use only with values YOU control
+//   %r  string, raw (NO escape) - use only with values YOU control
 //   %%  literal percent sign
 //
 // If you absolutely need to escape a string outside mysql_format, use
@@ -60,7 +60,7 @@ PersistPlayer(playerid, const note[])
     mysql_pquery(g_MysqlConn, query);
 }
 
-// Example 3: %r — raw, no escape. Only for trusted, hard-coded values.
+// Example 3: %r - raw, no escape. Only for trusted, hard-coded values.
 TruncateActionLog()
 {
     new query[128];

--- a/examples/05_orm.pwn
+++ b/examples/05_orm.pwn
@@ -1,12 +1,12 @@
-// 05_orm.pwn — minimal ORM: bind Pawn vars to columns, save / load by key.
+// 05_orm.pwn - minimal ORM: bind Pawn vars to columns, save / load by key.
 //
 // Workflow:
-//   1. orm_create(table, conn) — returns an orm_id tied to that table.
-//   2. orm_addvar_* — bind a Pawn variable to a column. Reads write into the
+//   1. orm_create(table, conn) - returns an orm_id tied to that table.
+//   2. orm_addvar_* - bind a Pawn variable to a column. Reads write into the
 //      var; writes pull the var's current value.
-//   3. orm_setkey(orm_id, "id") — declare the primary key. orm_save() decides
+//   3. orm_setkey(orm_id, "id") - declare the primary key. orm_save() decides
 //      INSERT vs UPDATE based on whether the key var is zero/empty.
-//   4. orm_select / orm_save / orm_delete / orm_insert / orm_update — async,
+//   4. orm_select / orm_save / orm_delete / orm_insert / orm_update - async,
 //      each with an optional callback.
 //
 // Schema assumed for the example:
@@ -72,7 +72,7 @@ public  OnPlayerLookup(playerid)
 {
     if (cache_get_row_count() == 0)
     {
-        // New player: orm_save with id=0 → INSERT.
+        // New player: orm_save with id=0 -> INSERT.
         orm_save(gPlayerOrm[playerid], "OnPlayerInserted", "d", playerid);
         return 1;
     }
@@ -107,7 +107,7 @@ public OnPlayerDisconnect(playerid, reason)
 
     if (gPlayerOrm[playerid] != 0 && gPlayerDbId[playerid] != 0)
     {
-        // Key is set → orm_save performs an UPDATE.
+        // Key is set -> orm_save performs an UPDATE.
         orm_save(gPlayerOrm[playerid]);
         orm_destroy(gPlayerOrm[playerid]);
         gPlayerOrm[playerid] = 0;

--- a/examples/06_ssl.pwn
+++ b/examples/06_ssl.pwn
@@ -1,14 +1,14 @@
-// 06_ssl.pwn — TLS connection. Requires mysql_samp v1.2.0 or later.
+// 06_ssl.pwn - TLS connection. Requires mysql_samp v1.2.0 or later.
 //
 // IMPORTANT: before v1.2.0 these options did NOT encrypt anything. The plugin
 // shipped without a TLS backend, so enabling SSL aborted the connection rather
 // than securing it. If you ran an older build with MYSQL_OPT_SSL on and it
-// appeared to work, that traffic was plaintext — rotate those credentials.
+// appeared to work, that traffic was plaintext - rotate those credentials.
 //
 //   - MYSQL_OPT_SSL = 1 turns on TLS (rustls, compiled into the plugin).
 //   - MYSQL_OPT_SSL_CA points at the root certificate that signed the server.
 //     WITHOUT it, only the webpki root bundle compiled into the plugin is
-//     trusted — NOT your operating system's trust store. A self-signed or
+//     trusted - NOT your operating system's trust store. A self-signed or
 //     internal-CA server will fail to connect until you set this.
 //   - MYSQL_OPT_SSL_CERT + MYSQL_OPT_SSL_KEY provide a client certificate when
 //     the server requires mutual TLS.
@@ -48,7 +48,7 @@ public OnGameModeInit()
     // --- DANGEROUS: disable verification ------------------------------------
     // Accepts ANY certificate and skips the hostname check. The traffic stays
     // encrypted, but anyone able to intercept the connection can present their
-    // own certificate and read or rewrite every query — which is exactly what
+    // own certificate and read or rewrite every query - which is exactly what
     // TLS exists to prevent. Set MYSQL_OPT_SSL_CA above instead.
     // mysql_options_set_int(opts, MYSQL_OPT_SSL_VERIFY_CERT, 0);
 

--- a/examples/07_error_handling.pwn
+++ b/examples/07_error_handling.pwn
@@ -1,15 +1,15 @@
-// 07_error_handling.pwn — OnQueryError, mysql_errno, mysql_error.
+// 07_error_handling.pwn - OnQueryError, mysql_errno, mysql_error.
 //
 // Every threaded query that fails (syntax error, constraint violation, lost
 // connection, ...) triggers OnQueryError BEFORE the regular callback.
 //
-//   errorid     — native MySQL error code (e.g. 1062 = duplicate key) or
+//   errorid     - native MySQL error code (e.g. 1062 = duplicate key) or
 //                 one of the MYSQL_ERROR_* codes (1..=8) for plugin-internal
 //                 failures.
-//   error[]     — human-readable message.
-//   callback[]  — the callback that would have been invoked on success.
-//   query[]     — the SQL text (may be truncated for very long queries).
-//   connId      — the connection that produced the error.
+//   error[]     - human-readable message.
+//   callback[]  - the callback that would have been invoked on success.
+//   query[]     - the SQL text (may be truncated for very long queries).
+//   connId      - the connection that produced the error.
 
 #include <a_samp>
 #include <mysql_samp>
@@ -44,7 +44,7 @@ public OnGameModeInit()
 forward OnNeverCalled();
 public  OnNeverCalled()
 {
-    // Won't run — OnQueryError fires first and the regular callback is skipped.
+    // Won't run - OnQueryError fires first and the regular callback is skipped.
     return 1;
 }
 
@@ -54,17 +54,17 @@ public OnQueryError(errorid, const error[], const callback[], const query[], con
     printf("[mysql]   callback: %s", callback);
     // Careful: this puts the whole statement in server_log.txt, including any
     // value interpolated by mysql_format. Drop this line when the query may
-    // carry sensitive data — or use prepared statements, where the values are
+    // carry sensitive data - or use prepared statements, where the values are
     // never part of the query text (see 08_prepared_statements.pwn).
     printf("[mysql]   query:    %s", query);
 
     // errorid is the native MySQL code (1146 = base table or view not found,
-    // 1062 = duplicate key, 1045 = access denied, ...) — handle the ones you
+    // 1062 = duplicate key, 1045 = access denied, ...) - handle the ones you
     // care about explicitly.
     switch (errorid)
     {
-        case 1062: printf("[mysql] duplicate key — ignoring");
-        case 1146: printf("[mysql] missing table — schema migration pending?");
+        case 1062: printf("[mysql] duplicate key - ignoring");
+        case 1146: printf("[mysql] missing table - schema migration pending?");
         default:   printf("[mysql] unhandled MySQL error %d", errorid);
     }
     return 1;

--- a/examples/08_prepared_statements.pwn
+++ b/examples/08_prepared_statements.pwn
@@ -1,4 +1,4 @@
-// 08_prepared_statements.pwn — the safe way to put player input in a query.
+// 08_prepared_statements.pwn - the safe way to put player input in a query.
 //
 // mysql_format escapes values into the SQL text. That works, but its
 // correctness depends on matching the server's sql_mode: under
@@ -10,7 +10,7 @@
 // SQL text for a value to break out of and no escaping involved at all.
 //
 // Bonus property: because the values never enter the query text, they also
-// never appear in logs/mysql.log or in cache_get_query_string() — only the
+// never appear in logs/mysql.log or in cache_get_query_string() - only the
 // template with its ? placeholders does.
 
 #include <a_samp>
@@ -51,7 +51,7 @@ FindPlayersByName(playerid, const name[], minScore)
     // Non-blocking and FIFO-ordered, exactly like mysql_query.
     mysql_stmt_execute(stmt, "OnPlayersFound", "d", playerid);
 
-    // The values were copied at execute time, so closing here is safe — the
+    // The values were copied at execute time, so closing here is safe - the
     // query is already on its way.
     mysql_stmt_close(stmt);
     return 1;
@@ -118,7 +118,7 @@ ClearPlayerClan(playerid, dbId)
 //
 //     mysql_stmt_new(conn, "SELECT * FROM ? ORDER BY ? ?");
 //
-// For those, build the SQL from values you control — a whitelist, never raw
+// For those, build the SQL from values you control - a whitelist, never raw
 // player input:
 //
 //     new const sortColumns[][] = { "score", "name", "created_at" };

--- a/examples/09_transactions.pwn
+++ b/examples/09_transactions.pwn
@@ -1,4 +1,4 @@
-// 09_transactions.pwn — all-or-nothing batches.
+// 09_transactions.pwn - all-or-nothing batches.
 //
 // A transaction guarantees that a group of statements either all apply or none
 // do. The classic case is moving money: without one, a crash or an error
@@ -60,7 +60,7 @@ TransferMoney(playerid, fromId, toId, amount)
     mysql_stmt_bind_int(stmt, amount);   // guard: never go negative
     mysql_transaction_add_stmt(tx, stmt);
 
-    // Credit — reuse the same statement object with a different body
+    // Credit - reuse the same statement object with a different body
     mysql_stmt_close(stmt);
     stmt = mysql_stmt_new(g_MysqlConn,
         "UPDATE accounts SET balance = balance + ? WHERE id = ?");
@@ -125,7 +125,7 @@ public OnDailyReset()
 
 // --- Abandoning a batch -------------------------------------------------------
 //
-// If you build a transaction and then decide not to run it, destroy it —
+// If you build a transaction and then decide not to run it, destroy it -
 // otherwise the handle stays around until the plugin unloads.
 //
 //     new tx = mysql_transaction_new(g_MysqlConn);

--- a/examples/10_password_hashing.pwn
+++ b/examples/10_password_hashing.pwn
@@ -1,4 +1,4 @@
-// 10_password_hashing.pwn — storing player passwords with Argon2id.
+// 10_password_hashing.pwn - storing player passwords with Argon2id.
 //
 // Never store a password with MD5, SHA1, or MySQL's PASSWORD()/SHA2() helpers.
 // Those are fast by design, which is the opposite of what password storage
@@ -14,7 +14,7 @@
 // about 100 characters. Use VARCHAR(255).
 //
 // It ALREADY CONTAINS a random per-hash salt. Do not add a salt column, and do
-// not reuse one — two players with the same password produce different hashes
+// not reuse one - two players with the same password produce different hashes
 // precisely so the table does not reveal that they match.
 //
 // Note the callback signature: the result is always the FIRST argument,

--- a/examples/11_config_and_scripts.pwn
+++ b/examples/11_config_and_scripts.pwn
@@ -1,12 +1,12 @@
-// 11_config_and_scripts.pwn — credentials in a file, schema in a file, and
+// 11_config_and_scripts.pwn - credentials in a file, schema in a file, and
 // queries that return more than one result set.
 //
 // Three things that usually show up together when a server grows past the
 // "one hardcoded connection" stage:
 //
-//   1. mysql_connect_file  — credentials outside the gamemode source.
-//   2. mysql_query_file    — schema and migrations as .sql files.
-//   3. cache_set_result    — reading a stored procedure that returns several
+//   1. mysql_connect_file  - credentials outside the gamemode source.
+//   2. mysql_query_file    - schema and migrations as .sql files.
+//   3. cache_set_result    - reading a stored procedure that returns several
 //                            result sets.
 //
 // Companion files in this folder: mysql.ini.example and schema.sql.
@@ -19,7 +19,7 @@ new g_MysqlConn = 0;
 // --- 1. Connecting from a config file ----------------------------------------
 //
 // The credentials live in mysql.ini, which your repository does not carry.
-// Connection OPTIONS stay here in code — there is one place to look for
+// Connection OPTIONS stay here in code - there is one place to look for
 // tuning, and the file holds nothing but credentials.
 
 public OnGameModeInit()
@@ -83,7 +83,7 @@ public OnQueryError(errorid, const error[], const callback[], const query[], con
     {
         // The message names the position, e.g. "statement 3 of 4: ...".
         printf("[mysql] schema failed (%d): %s", errorid, error);
-        printf("[mysql] statements before it are already applied — fix and re-run");
+        printf("[mysql] statements before it are already applied - fix and re-run");
     }
     return 1;
 }
@@ -117,7 +117,7 @@ public OnOverviewLoaded(playerid)
     printf("[mysql] procedure returned %d result set(s)", sets);
 
     // Result 0 is selected by default, so a single-set query needs none of
-    // this — existing code keeps working unchanged.
+    // this - existing code keeps working unchanged.
 
     // First set: the account row.
     if (cache_set_result(0) && cache_get_row_count() > 0)

--- a/examples/mysql.ini.example
+++ b/examples/mysql.ini.example
@@ -1,6 +1,6 @@
 # Copy this to mysql.ini and fill in your own values.
 #
-# Keep the real file OUT of version control — that is the whole point of
+# Keep the real file OUT of version control - that is the whole point of
 # mysql_connect_file. Add it to .gitignore:
 #
 #     mysql.ini

--- a/examples/schema.sql
+++ b/examples/schema.sql
@@ -23,7 +23,7 @@ CREATE TABLE IF NOT EXISTS audit_log (
 
 # A hash-style comment is also skipped by the splitter.
 
-/* A block comment containing a semicolon ; and a quote ' — neither ends
+/* A block comment containing a semicolon ; and a quote ' - neither ends
    a statement, and the scanner walks past both. */
 
 INSERT INTO audit_log (note) VALUES ('schema applied; version 1');


### PR DESCRIPTION
## O quê

Comentários em `examples/*.pwn`, `benchmark/*.pwn`, `examples/schema.sql` e `examples/mysql.ini.example` usavam em-dash (`—`, U+2014) e uma seta (`→`, U+2192). Num arquivo Pawn aberto ou compilado como latin-1, esses bytes UTF-8 viram lixo (`â€"`). Trocados por `-` e `->` ASCII.

## Escopo

15 arquivos, **só comentários e strings de exemplo** — nenhuma lógica mudou. Todos os `.pwn` recompilam com o pawncc após a troca (verificado).

Fora do escopo de propósito:
- **`.md`** — markdown é renderizado como UTF-8; em-dash é correto ali, e todos os outros `.md` do projeto usam.
- **`.rs`** — Rust é UTF-8 nativo, sem risco.
- **`include/*.inc` / `.inc.in`** — já tratados no PR #34, tocá-los aqui causaria conflito.

## Inventário

Varredura de codepoints não-ASCII confirmou só dois em toda a árvore Pawn: `U+2014` (63x) e `U+2192` (2x). Nenhum outro caractere suspeito (aspas curvas, reticências, etc.).
