### PR TITLE
release: v1.3.0 (JavaDoc, open.mp include, cleartext-logging fix, build cache)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,37 @@ All notable changes to this project are documented in this file.
 
 Format inspired by [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/). Older entries live under [`changelog/`](changelog/).
 
-## [Unreleased]
+## [1.3.0] — 2026/09/07
+
+Built on rust-samp v3.4.0 (unchanged since 1.2.0). Additive release: no Pawn native was removed or renamed, so 1.2.0 gamemodes compile unchanged.
 
 ### Added
 
-- **open.mp naming style** — a second include, `<mysql_samp_omp>`, exposes every native under open.mp's `Prefix_PascalCase` convention: `MySQL_Connect`, `MySQL_Query`, `Cache_GetRowCount`, `ORM_Create`, `MySQL_TransactionExecute`, `MySQL_HashPassword`, and so on. Each name is a Pawn alias (`native MySQL_Connect(...) = mysql_connect;`) to the real snake_case native, so there is **no runtime cost and no change on the plugin side** — the same `.so`/`.dll` serves both. Include `<mysql_samp>` for the original style or `<mysql_samp_omp>` for the styled one — they are alternatives, not layers, so pick one per script. The styled include is self-contained (it carries its own copy of the `MYSQL_OPT_*` enums and the `OnQueryError` forward) and is generated from the base by `build.rs` on every build, so the two can never drift: a native, enum or constant added to the template appears in both automatically.
+- **open.mp naming style** — a second include, `<mysql_samp_omp>`, exposes every native under open.mp's `Prefix_PascalCase` convention: `MySQL_Connect`, `MySQL_Query`, `Cache_GetRowCount`, `ORM_Create`, `MySQL_TransactionExecute`, `MySQL_HashPassword`, and so on. Each name is a Pawn alias (`native MySQL_Connect(...) = mysql_connect;`) to the real snake_case native, so there is **no runtime cost and no change on the plugin side** — the same `.so`/`.dll` serves both. Include `<mysql_samp>` for the original style or `<mysql_samp_omp>` for the styled one — they are alternatives, not layers, so pick one per script. The styled include is self-contained (it carries its own copy of the `MYSQL_OPT_*` enums and the `OnQueryError` forward) and is generated from the base by `build.rs` on every build, so the two can never drift: a native, enum or constant added to the template appears in both automatically. (#34)
+- **JavaDoc on every native and on `OnQueryError`.** The include now documents each entry with a `/** */` block (`@param` / `@return`) — the style PawnPro surfaces on hover and autocomplete, and clearer than an XML doc comment. Short and to the point: one line of description, one `@param` per argument, one `@return`. The blocks flow into both includes from the same source. (#36)
+
+### Fixed
+
+- **`rust/cleartext-logging` alerts from CodeQL, closed by breaking the taint path.** These are false positives — the password never reaches a log — but they were fixed in code rather than dismissed (dismissal is repo state that decays as lines move). Two steps: #33 replaced the free-form failure `String` with a fixed `PasswordFailure` enum, and this release finishes the job. Reading the SARIF showed CodeQL still traced a second path — `poll_results()` → the callback info → `invoke_callback` → a `Logger::error` that interpolated `info.name` (the callback name like `"OnHashed"`, not the password, but CodeQL cannot tell a struct field from the secret). Those two infrastructure error logs no longer interpolate the callback name, so nothing from the password flow reaches a log at all. (#33 and this release)
+
+### Changed
+
+- **`build.rs` now declares its real inputs** (`cargo:rerun-if-changed` on the template, the script and the manifest). Editing a generated `.inc`, an example, or a doc no longer re-runs the build script or invalidates the Rust test cache — only a change to the template, `build.rs`, or `Cargo.toml` triggers regeneration. A clean build (releases) still stamps the current `BUILD_*` banner values.
+- **Dropped the `proc-macro-error2` dependency** by updating `mysql_common` 0.37.1 → 0.37.3 (lockfile only), which clears a Rust future-incompatibility warning. The crate sat three levels down under `mysql` and never affected the shipped binary. (#20)
+- **Example and benchmark files are now pure ASCII.** Em-dashes and an arrow in the `.pwn`, `.sql` and `.ini.example` comments became `-` and `->`, so a Pawn file opened or compiled as latin-1 no longer shows garbage. Comments only; every example still compiles. (#35)
+
+### CI / tooling
+
+- CodeQL moved from the default to the advanced setup, so every commit is scanned. (#30)
+- Dependabot updates are grouped into one PR per ecosystem (github-actions, cargo, pip). (#29)
+- Routine dependency and action bumps: `mkdocs-material`, `pymdown-extensions`, `taiki-e/install-action`, `github/codeql-action`, `actions/checkout`, `actions/setup-python`, `actions/cache`, `Swatinem/rust-cache`. (#16–#32)
+
+### Known advisories
+
+Both are informational and neither is resolvable here — each is pinned behind the `mysql` crate's version requirements, and Dependabot will pull the fix once upstream loosens them:
+
+- **RUSTSEC-2025-0134** — `rustls-pemfile` is unmaintained. The code that actually runs is the maintained `rustls-pki-types`; the flagged crate is a thin wrapper over it.
+- **RUSTSEC-2026-0253** — `lru` is unsound in `LruCache::pop` if a key's `Drop` panics. The driver's cache keys are strings/ints, whose `Drop` never panics, so the trigger is unreachable in practice.
 
 ## [1.2.0] — 2026/08/05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "mysql_samp"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "argon2",
  "fern",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mysql_samp"
-version = "1.2.0"
+version = "1.3.0"
 edition = "2024"
 authors = ["NullSablex <https://github.com/NullSablex>"]
 repository = "https://github.com/NullSablex/mysql_samp"

--- a/build.rs
+++ b/build.rs
@@ -27,6 +27,18 @@ fn main() {
     println!("cargo:rustc-env=BUILD_TIME={time}");
     println!("cargo:rustc-env=BUILD_YEAR={year}");
 
+    // Declare the script's real inputs. Without this, Cargo assumes the build
+    // script depends on every file in the package, so editing a generated .inc,
+    // an example, or a doc re-runs the script and invalidates the Rust
+    // build/test cache for no reason. Listing the inputs scopes the re-run to
+    // what actually feeds the generation: the template, this script, and the
+    // manifest (for the version). A clean build (releases) still runs the
+    // script, so BUILD_* reflect that build; incremental dev builds keep the
+    // BUILD_* from the last input change, which is fine for the banner.
+    println!("cargo:rerun-if-changed=include/mysql_samp.inc.in");
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=Cargo.toml");
+
     generate_inc();
 }
 
@@ -36,11 +48,9 @@ fn generate_inc() {
     let template_path = "include/mysql_samp.inc.in";
     let output_path = "include/mysql_samp.inc";
 
-    // No `cargo:rerun-if-changed` directives: build.rs runs on every build
-    // so the .inc tracks the current Cargo version, build date and template
-    // without manual intervention. The write below is idempotent - it only
-    // touches disk when the rendered output actually differs from the file
-    // on disk, so the always-run policy does not churn timestamps.
+    // The write below is idempotent: it only touches disk when the rendered
+    // output actually differs, so a re-run never churns timestamps (which would
+    // otherwise cascade back into the build).
 
     let template = fs::read_to_string(template_path)
         .unwrap_or_else(|e| panic!("failed to read {template_path}: {e}"));

--- a/include/mysql_samp.inc
+++ b/include/mysql_samp.inc
@@ -59,161 +59,720 @@ enum {
     ORM_NO_DATA,
 }
 
-// Forward: invoked when a threaded query fails.
+/**
+ * Fired on every loaded script when a threaded query fails.
+ *
+ * @param errorid   MySQL error code (1062, 1045, ...), or 0 for transport errors
+ * @param error     server error message
+ * @param callback  the callback the query asked for, or "" if none
+ * @param query     the SQL that failed
+ * @param connId    connection that produced the error
+ */
 forward OnQueryError(errorid, const error[], const callback[], const query[], connId);
 
 // Options
+
+/**
+ * Creates an options handle for a connection.
+ *
+ * @return the options handle (>= 1), or 0 on failure
+ */
 native mysql_options_new();
+
+/**
+ * Sets an integer option (MYSQL_OPT_PORT, MYSQL_OPT_SSL, ...).
+ *
+ * @param handle  an options handle
+ * @param option  a MYSQL_OPT_* value that takes an int
+ * @param value   the value
+ * @return true on success, false on a bad handle or type mismatch
+ */
 native bool:mysql_options_set_int(handle, option, value);
+
+/**
+ * Sets a string option (MYSQL_OPT_SSL_CA, MYSQL_OPT_SSL_CERT, MYSQL_OPT_SSL_KEY).
+ *
+ * @param handle  an options handle
+ * @param option  a MYSQL_OPT_* value that takes a string
+ * @param value   the value
+ * @return true on success, false on a bad handle or type mismatch
+ */
 native bool:mysql_options_set_str(handle, option, const value[]);
 
 // Connection
+
+/**
+ * Opens a connection pool.
+ *
+ * @param host      hostname/IP, or a path starting with / for a unix socket
+ * @param user      MySQL user
+ * @param password  MySQL password
+ * @param database  default schema
+ * @param options   an options handle, or 0 for defaults
+ * @return connection id (>= 1), or 0 on failure
+ */
 native mysql_connect(const host[], const user[], const password[], const database[], options = 0);
-// Reads host / user / password / database from a `key = value` file, keeping
-// credentials out of the gamemode source. Options stay with mysql_options_new.
+
+/**
+ * Opens a connection reading host/user/password/database from a
+ * `key = value` file, keeping credentials out of the gamemode source.
+ *
+ * @param path     path to the config file
+ * @param options  an options handle, or 0 for defaults
+ * @return connection id (>= 1), or 0 on failure
+ */
 native mysql_connect_file(const path[] = "mysql.ini", options = 0);
+
+/**
+ * Closes a connection and frees its statements and transactions.
+ *
+ * @param connId  connection id
+ * @return true on success, false if the id is unknown
+ */
 native bool:mysql_close(connId);
+
+/**
+ * Writes a short server-status line into dest.
+ *
+ * @param connId   connection id
+ * @param dest     destination buffer
+ * @param max_len  size of dest
+ * @return true on success, false on failure
+ */
 native bool:mysql_status(connId, dest[], max_len = sizeof(dest));
 
 // Error
+
+/**
+ * Last error code for a connection.
+ *
+ * @param connId  connection id, or 0 for the global error
+ * @return the MySQL error code, a MYSQL_ERROR_* value, or 0 for none
+ */
 native mysql_errno(connId = 0);
+
+/**
+ * Writes the last error message into dest.
+ *
+ * @param connId   connection id, or 0 for the global error
+ * @param dest     destination buffer
+ * @param max_len  size of dest
+ * @return true on success, false on failure
+ */
 native bool:mysql_error(connId, dest[], max_len = sizeof(dest));
 
 // Charset
+
+/**
+ * Runs SET NAMES to change the connection charset.
+ *
+ * @param connId   connection id
+ * @param charset  charset name (e.g. "utf8mb4")
+ * @return true on success, false on failure
+ */
 native bool:mysql_set_charset(connId, const charset[]);
+
+/**
+ * Reads the connection's current charset into dest.
+ *
+ * @param connId   connection id
+ * @param dest     destination buffer
+ * @param max_len  size of dest
+ * @return true on success, false on failure
+ */
 native bool:mysql_get_charset(connId, dest[], max_len = sizeof(dest));
 
 // Utility
+
+/**
+ * Number of queries submitted but not yet dispatched to a callback.
+ *
+ * @return the pending count
+ */
 native mysql_unprocessed_queries();
+
+/**
+ * Sets the minimum log level at runtime.
+ *
+ * @param log_level  a MYSQL_LOG_* value
+ * @return true
+ */
 native bool:mysql_log(log_level);
 
 // Query (non-blocking)
+
+/**
+ * Runs a query on a worker thread, FIFO-ordered.
+ *
+ * @param connId    connection id
+ * @param query     the SQL
+ * @param callback  callback to fire with the result, or "" for none
+ * @param format    types of the extra callback args ("d" int, "f" float, "s" string)
+ * @return true if submitted, false on a bad connection
+ */
 native bool:mysql_query(connId, const query[], const callback[] = "", const format[] = "", {Float,_}:...);
+
+/**
+ * Runs a query on a worker thread, parallel: no ordering guarantee.
+ *
+ * @param connId    connection id
+ * @param query     the SQL
+ * @param callback  callback to fire with the result, or "" for none
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on a bad connection
+ */
 native bool:mysql_pquery(connId, const query[], const callback[] = "", const format[] = "", {Float,_}:...);
-// Kept for backwards compatibility only: since rust-samp v3.0.0 the unified
-// on_tick already dispatches callbacks automatically on SA-MP and native open.mp.
+
+/**
+ * Drains the dispatch queue manually. You do not need to call this: since
+ * rust-samp v3.0.0 the queue is pumped automatically every tick. Kept for
+ * backwards compatibility.
+ *
+ * @return true
+ */
 native bool:mysql_tick();
-// connId selects the escaping rules, which depend on the server's sql_mode.
-// Pass the real connection whenever the server may run with NO_BACKSLASH_ESCAPES;
-// 0 assumes the MySQL default.
+
+/**
+ * Escapes a string for use inside a single-quoted SQL literal.
+ *
+ * @param src      the raw string
+ * @param dest     destination buffer
+ * @param max_len  size of dest
+ * @param connId   connection whose sql_mode picks the escaping rules; pass the
+ *                 real one when the server may run NO_BACKSLASH_ESCAPES (0 assumes
+ *                 the MySQL default)
+ * @return true on success, false on failure
+ */
 native bool:mysql_escape_string(const src[], dest[], max_len = sizeof(dest), connId = 0);
+
+/**
+ * Builds a query into dest with printf-style specifiers (%d, %f, %s escaped,
+ * %e escaped, %r raw). Truncates at the buffer boundary.
+ *
+ * @param connId   connection whose sql_mode picks the escaping rules
+ * @param dest     destination buffer
+ * @param max_len  size of dest
+ * @param format   the format string
+ * @return bytes written into dest
+ */
 native mysql_format(connId, dest[], max_len, const format[], {Float,_}:...);
-// Runs the statements of a .sql file in order on one connection, non-blocking.
-// Split on `;` outside literals and comments. NOT transactional: DDL commits
-// implicitly in MySQL. Stops at the first failure, naming which statement.
+
+/**
+ * Runs the statements of a .sql file in order on one connection, non-blocking.
+ * Split on `;` outside literals and comments. NOT transactional: DDL commits
+ * implicitly in MySQL, and on failure the statements before it stay applied.
+ *
+ * @param connId    connection id
+ * @param path      path to the .sql file
+ * @param callback  callback to fire with the last statement's result, or ""
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on a bad connection or unreadable file
+ */
 native bool:mysql_query_file(connId, const path[], const callback[] = "", const format[] = "", {Float,_}:...);
 
-// Prepared statements (non-blocking, FIFO like mysql_query)
-//
-// Values are bound server-side over the binary protocol instead of being pasted
-// into the SQL text, so no escaping is involved and a value can never be
-// reinterpreted as syntax. Prefer this over mysql_format for anything that
-// carries player input.
-//
-//   new stmt = mysql_stmt_new(connId, "SELECT id FROM users WHERE name = ? AND age > ?");
-//   mysql_stmt_bind_str(stmt, inputName);
-//   mysql_stmt_bind_int(stmt, 18);
-//   mysql_stmt_execute(stmt, "OnUsersFound", "d", playerid);
-//
-// The statement is reusable: call mysql_stmt_reset to drop the bound values and
-// bind a fresh set. mysql_stmt_execute fails if the number of bound values does
-// not match the number of ? placeholders.
+// Prepared statements (non-blocking, FIFO)
+
+/**
+ * Creates a prepared statement. Use `?` for each bound value.
+ *
+ * @param connId  connection id
+ * @param query   the SQL with `?` placeholders
+ * @return statement id (>= 1), or 0 on a bad connection
+ */
 native mysql_stmt_new(connId, const query[]);
+
+/**
+ * Frees a statement.
+ *
+ * @param stmtId  statement id
+ * @return true on success, false if the id is unknown
+ */
 native bool:mysql_stmt_close(stmtId);
+
+/**
+ * Clears the bound values, keeping the statement for reuse.
+ *
+ * @param stmtId  statement id
+ * @return true on success, false if the id is unknown
+ */
 native bool:mysql_stmt_reset(stmtId);
+
+/**
+ * Binds an integer to the next placeholder.
+ *
+ * @param stmtId  statement id
+ * @param value   the value
+ * @return true on success, false if the id is unknown or the limit is reached
+ */
 native bool:mysql_stmt_bind_int(stmtId, value);
+
+/**
+ * Binds a float to the next placeholder.
+ *
+ * @param stmtId  statement id
+ * @param value   the value
+ * @return true on success, false if the id is unknown or the limit is reached
+ */
 native bool:mysql_stmt_bind_float(stmtId, Float:value);
+
+/**
+ * Binds a string to the next placeholder.
+ *
+ * @param stmtId  statement id
+ * @param value   the value
+ * @return true on success, false if the id is unknown or the limit is reached
+ */
 native bool:mysql_stmt_bind_str(stmtId, const value[]);
+
+/**
+ * Binds SQL NULL to the next placeholder.
+ *
+ * @param stmtId  statement id
+ * @return true on success, false if the id is unknown or the limit is reached
+ */
 native bool:mysql_stmt_bind_null(stmtId);
+
+/**
+ * Executes a statement, FIFO-ordered. Fails if the number of bound values does
+ * not match the number of `?` placeholders.
+ *
+ * @param stmtId    statement id
+ * @param callback  callback to fire with the result, or "" for none
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on a bad id or arity mismatch
+ */
 native bool:mysql_stmt_execute(stmtId, const callback[] = "", const format[] = "", {Float,_}:...);
-// Parallel counterpart, mirroring mysql_pquery: no ordering guarantee.
+
+/**
+ * Executes a statement on a worker thread, parallel: no ordering guarantee.
+ *
+ * @param stmtId    statement id
+ * @param callback  callback to fire with the result, or "" for none
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on a bad id or arity mismatch
+ */
 native bool:mysql_stmt_pexecute(stmtId, const callback[] = "", const format[] = "", {Float,_}:...);
 
-// Cache
+// Cache (read inside a query callback)
+
+/**
+ * Rows in the active result set.
+ *
+ * @return the row count
+ */
 native cache_get_row_count();
+
+/**
+ * Columns in the active result set.
+ *
+ * @return the field count
+ */
 native cache_get_field_count();
+
+/**
+ * Writes a column's name into dest.
+ *
+ * @param field_idx  column index
+ * @param dest       destination buffer
+ * @param max_len    size of dest
+ * @return true on success, false if the index is out of range
+ */
 native bool:cache_get_field_name(field_idx, dest[], max_len = sizeof(dest));
+
+/**
+ * A column's MySQL type (a raw ColumnType byte).
+ *
+ * @param field_idx  column index
+ * @return the type byte, or 0 if out of range
+ */
 native cache_get_field_type(field_idx);
+
+/**
+ * Reads a cell as a string, by column index.
+ *
+ * @param row      row index
+ * @param col      column index
+ * @param dest     destination buffer
+ * @param max_len  size of dest
+ * @return true on success, false if out of range
+ */
 native bool:cache_get_value_index(row, col, dest[], max_len = sizeof(dest));
+
+/**
+ * Reads a cell as an int, by column index.
+ *
+ * @param row  row index
+ * @param col  column index
+ * @return the value, or 0 if out of range or NULL
+ */
 native cache_get_value_index_int(row, col);
+
+/**
+ * Reads a cell as a float, by column index.
+ *
+ * @param row  row index
+ * @param col  column index
+ * @return the value, or 0.0 if out of range or NULL
+ */
 native Float:cache_get_value_index_float(row, col);
+
+/**
+ * Reads a cell as a string, by column name (case-insensitive).
+ *
+ * @param row         row index
+ * @param field_name  column name
+ * @param dest        destination buffer
+ * @param max_len     size of dest
+ * @return true on success, false if the row or name is unknown
+ */
 native bool:cache_get_value_name(row, const field_name[], dest[], max_len = sizeof(dest));
+
+/**
+ * Reads a cell as an int, by column name.
+ *
+ * @param row         row index
+ * @param field_name  column name
+ * @return the value, or 0 if unknown or NULL
+ */
 native cache_get_value_name_int(row, const field_name[]);
+
+/**
+ * Reads a cell as a float, by column name.
+ *
+ * @param row         row index
+ * @param field_name  column name
+ * @return the value, or 0.0 if unknown or NULL
+ */
 native Float:cache_get_value_name_float(row, const field_name[]);
+
+/**
+ * Whether a cell is SQL NULL, by column index.
+ *
+ * @param row  row index
+ * @param col  column index
+ * @return true if NULL
+ */
 native bool:cache_is_value_index_null(row, col);
+
+/**
+ * Whether a cell is SQL NULL, by column name.
+ *
+ * @param row         row index
+ * @param field_name  column name
+ * @return true if NULL
+ */
 native bool:cache_is_value_name_null(row, const field_name[]);
+
+/**
+ * Rows affected by the last INSERT/UPDATE/DELETE.
+ *
+ * @return the affected-row count
+ */
 native cache_affected_rows();
+
+/**
+ * AUTO_INCREMENT id generated by the last INSERT.
+ *
+ * @return the insert id
+ */
 native cache_insert_id();
+
+/**
+ * Warnings the server raised for the query.
+ *
+ * @return the warning count
+ */
 native cache_warning_count();
+
+/**
+ * How long the query took to execute.
+ *
+ * @return the time in milliseconds
+ */
 native cache_get_query_exec_time();
+
+/**
+ * Writes the query text into dest.
+ *
+ * @param dest     destination buffer
+ * @param max_len  size of dest
+ * @return true on success, false on failure
+ */
 native bool:cache_get_query_string(dest[], max_len = sizeof(dest));
-// Result sets in the active cache. A plain query yields 1; a script or a
-// stored-procedure CALL can yield several. cache_set_result picks which one
-// every other cache_* native reports on (index 0 until changed).
+
+/**
+ * Result sets in the active cache. A plain query yields 1; a stored-procedure
+ * CALL or a script can yield several.
+ *
+ * @return the result-set count
+ */
 native cache_get_result_count();
+
+/**
+ * Selects which result set the other cache_* natives read (0 until changed).
+ *
+ * @param result_index  result-set index
+ * @return true on success, false if the index is out of range
+ */
 native bool:cache_set_result(result_index);
 
+/**
+ * Persists the active cache so it can be read after the callback returns.
+ *
+ * @return a saved-cache id (>= 1), or 0 on failure
+ */
 native cache_save();
+
+/**
+ * Frees a saved cache.
+ *
+ * @param cache_id  id from cache_save
+ * @return true on success, false if the id is unknown
+ */
 native bool:cache_delete(cache_id);
+
+/**
+ * Makes a saved cache the active one.
+ *
+ * @param cache_id  id from cache_save
+ * @return true on success, false if the id is unknown
+ */
 native bool:cache_set_active(cache_id);
+
+/**
+ * Clears the manually set active cache.
+ *
+ * @return true on success, false if none was set
+ */
 native bool:cache_unset_active();
+
+/**
+ * Whether any cache is currently active.
+ *
+ * @return true if one is active
+ */
 native bool:cache_is_any_active();
+
+/**
+ * Whether a saved-cache id is still valid.
+ *
+ * @param cache_id  id from cache_save
+ * @return true if valid
+ */
 native bool:cache_is_valid(cache_id);
 
-// ORM
+// ORM (bind Pawn variables to columns)
+
+/**
+ * Creates an ORM instance bound to a table.
+ *
+ * @param table   table name
+ * @param connId  connection id
+ * @return an ORM id (>= 1), or 0 on a bad connection
+ */
 native orm_create(const table[], connId);
+
+/**
+ * Destroys an ORM instance.
+ *
+ * @param orm_id  ORM id
+ * @return true on success, false if the id is unknown
+ */
 native bool:orm_destroy(orm_id);
+
+/**
+ * Last ORM error. Only the apply-cache operation sets it.
+ *
+ * @param orm_id  ORM id
+ * @return ORM_OK or ORM_NO_DATA
+ */
 native orm_errno(orm_id);
+
+/**
+ * SELECTs the row matching the key and fills the bound variables.
+ *
+ * @param orm_id    ORM id
+ * @param callback  callback to fire when done, or ""
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on failure
+ */
 native bool:orm_select(orm_id, const callback[] = "", const format[] = "", {Float,_}:...);
+
+/**
+ * UPDATEs the row matching the key with the bound variables.
+ *
+ * @param orm_id    ORM id
+ * @param callback  callback to fire when done, or ""
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on failure
+ */
 native bool:orm_update(orm_id, const callback[] = "", const format[] = "", {Float,_}:...);
+
+/**
+ * INSERTs a row from the bound variables.
+ *
+ * @param orm_id    ORM id
+ * @param callback  callback to fire when done, or ""
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on failure
+ */
 native bool:orm_insert(orm_id, const callback[] = "", const format[] = "", {Float,_}:...);
+
+/**
+ * DELETEs the row matching the key.
+ *
+ * @param orm_id    ORM id
+ * @param callback  callback to fire when done, or ""
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on failure
+ */
 native bool:orm_delete(orm_id, const callback[] = "", const format[] = "", {Float,_}:...);
+
+/**
+ * INSERTs when the key is empty, UPDATEs otherwise.
+ *
+ * @param orm_id    ORM id
+ * @param callback  callback to fire when done, or ""
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on failure
+ */
 native bool:orm_save(orm_id, const callback[] = "", const format[] = "", {Float,_}:...);
+
+/**
+ * Copies a row from the active cache into the bound variables.
+ *
+ * @param orm_id  ORM id
+ * @param row     row index in the active cache
+ * @return true on success, false if there is no such row
+ */
 native bool:orm_apply_cache(orm_id, row = 0);
+
+/**
+ * Binds an int variable to a column.
+ *
+ * @param orm_id       ORM id
+ * @param var          the variable (read on write, written on load)
+ * @param column_name  column name
+ * @return true on success, false if the id is unknown
+ */
 native bool:orm_addvar_int(orm_id, &var, const column_name[]);
+
+/**
+ * Binds a float variable to a column.
+ *
+ * @param orm_id       ORM id
+ * @param var          the variable
+ * @param column_name  column name
+ * @return true on success, false if the id is unknown
+ */
 native bool:orm_addvar_float(orm_id, &Float:var, const column_name[]);
+
+/**
+ * Binds a string variable to a column.
+ *
+ * @param orm_id       ORM id
+ * @param var          the buffer
+ * @param var_max_len  size of the buffer (capped at 4096)
+ * @param column_name  column name
+ * @return true on success, false on a bad id or length
+ */
 native bool:orm_addvar_string(orm_id, var[], var_max_len, const column_name[]);
+
+/**
+ * Unbinds a column.
+ *
+ * @param orm_id       ORM id
+ * @param column_name  column name
+ * @return true if a binding was removed
+ */
 native bool:orm_delvar(orm_id, const column_name[]);
+
+/**
+ * Removes all bindings.
+ *
+ * @param orm_id  ORM id
+ * @return true on success, false if the id is unknown
+ */
 native bool:orm_clear_vars(orm_id);
+
+/**
+ * Sets which bound column is the key for select/update/delete/save.
+ *
+ * @param orm_id       ORM id
+ * @param column_name  column name
+ * @return true on success, false if the id is unknown
+ */
 native bool:orm_setkey(orm_id, const column_name[]);
 
 // Password hashing (Argon2id)
-//
-// Both natives run on a worker thread - Argon2id is deliberately slow, so
-// hashing on the server thread would stall it. The result is delivered as the
-// FIRST argument of the callback, followed by the extras described by format.
-//
-//   forward OnHashed(const hash[], playerid);
-//   mysql_hash_password("secret", "OnHashed", "d", playerid);
-//
-//   forward OnChecked(bool:success, playerid);
-//   mysql_verify_password("secret", stored_hash, "OnChecked", "d", playerid);
-//
-// The hash is a PHC string (`$argon2id$v=19$m=...`) around 100 characters long;
-// size the storage column and any Pawn buffer accordingly (VARCHAR(255) is the
-// usual choice). It already embeds its own random salt - do not add one.
+
+/**
+ * Hashes a password with Argon2id, off the server thread.
+ *
+ * @param password  the plaintext
+ * @param callback  callback receiving the PHC hash as its first argument
+ * @param format    types of the extra callback args
+ * @return true if queued, false if the callback is empty, the password exceeds
+ *         1 KiB, or the work queue is full
+ */
 native bool:mysql_hash_password(const password[], const callback[], const format[] = "", {Float,_}:...);
+
+/**
+ * Verifies a password against a stored PHC hash, off the server thread.
+ *
+ * @param password  the plaintext
+ * @param hash      the stored PHC string
+ * @param callback  callback receiving the bool result as its first argument
+ * @param format    types of the extra callback args
+ * @return true if queued, false if the callback is empty, the password exceeds
+ *         1 KiB, or the work queue is full
+ */
 native bool:mysql_verify_password(const password[], const hash[], const callback[], const format[] = "", {Float,_}:...);
 
 // Transactions (non-blocking, all-or-nothing)
-//
-// Steps are collected first and then executed as one unit on a single
-// connection: START TRANSACTION, every step, COMMIT. Any failing step rolls the
-// whole batch back and fires OnQueryError. There is no interactive
-// begin/commit API on purpose - holding a pooled connection between ticks would
-// leak it whenever a gamemode never reached the commit.
-//
-//   new tx = mysql_transaction_new(connId);
-//   mysql_transaction_add(tx, "UPDATE accounts SET balance = balance - 100 WHERE id = 1");
-//   mysql_transaction_add(tx, "UPDATE accounts SET balance = balance + 100 WHERE id = 2");
-//   mysql_transaction_execute(tx, "OnTransferDone", "d", playerid);
-//
-// mysql_transaction_add_stmt appends a prepared statement with its bound values,
-// which is the safe way to put player input inside a transaction.
-// mysql_transaction_execute consumes the handle: the ID is invalid afterwards.
-// The callback receives the cache of the LAST step.
+
+/**
+ * Creates a transaction.
+ *
+ * @param connId  connection id
+ * @return a transaction id (>= 1), or 0 on a bad connection
+ */
 native mysql_transaction_new(connId);
+
+/**
+ * Discards a transaction that was never executed.
+ *
+ * @param txId  transaction id
+ * @return true on success, false if the id is unknown
+ */
 native bool:mysql_transaction_destroy(txId);
+
+/**
+ * Appends a plain SQL step.
+ *
+ * @param txId   transaction id
+ * @param query  the SQL
+ * @return true on success, false if the id is unknown
+ */
 native bool:mysql_transaction_add(txId, const query[]);
+
+/**
+ * Appends a prepared statement with its bound values - the safe way to put
+ * player input in a transaction. The statement itself is untouched.
+ *
+ * @param txId    transaction id
+ * @param stmtId  statement id
+ * @return true on success, false on a bad id or arity mismatch
+ */
 native bool:mysql_transaction_add_stmt(txId, stmtId);
+
+/**
+ * Runs every step atomically, then destroys the transaction (the id is invalid
+ * afterwards). The callback receives the cache of the LAST step.
+ *
+ * @param txId      transaction id
+ * @param callback  callback to fire on commit, or ""
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on a bad id or empty batch
+ */
 native bool:mysql_transaction_execute(txId, const callback[] = "", const format[] = "", {Float,_}:...);

--- a/include/mysql_samp.inc
+++ b/include/mysql_samp.inc
@@ -1,5 +1,5 @@
 /*
- * mysql_samp v1.2.0 - MySQL plugin for SA-MP and Open Multiplayer.
+ * mysql_samp v1.3.0 - MySQL plugin for SA-MP and Open Multiplayer.
  * Author:     NullSablex
  * Repository: https://github.com/NullSablex/mysql_samp
  * License:    GPL-3.0
@@ -10,7 +10,7 @@
 #endif
 #define _mysql_samp_included
 
-#define MYSQL_SAMP_VERSION "1.2.0"
+#define MYSQL_SAMP_VERSION "1.3.0"
 
 // Connection options
 enum {

--- a/include/mysql_samp.inc.in
+++ b/include/mysql_samp.inc.in
@@ -59,161 +59,720 @@ enum {
     ORM_NO_DATA,
 }
 
-// Forward: invoked when a threaded query fails.
+/**
+ * Fired on every loaded script when a threaded query fails.
+ *
+ * @param errorid   MySQL error code (1062, 1045, ...), or 0 for transport errors
+ * @param error     server error message
+ * @param callback  the callback the query asked for, or "" if none
+ * @param query     the SQL that failed
+ * @param connId    connection that produced the error
+ */
 forward OnQueryError(errorid, const error[], const callback[], const query[], connId);
 
 // Options
+
+/**
+ * Creates an options handle for a connection.
+ *
+ * @return the options handle (>= 1), or 0 on failure
+ */
 native mysql_options_new();
+
+/**
+ * Sets an integer option (MYSQL_OPT_PORT, MYSQL_OPT_SSL, ...).
+ *
+ * @param handle  an options handle
+ * @param option  a MYSQL_OPT_* value that takes an int
+ * @param value   the value
+ * @return true on success, false on a bad handle or type mismatch
+ */
 native bool:mysql_options_set_int(handle, option, value);
+
+/**
+ * Sets a string option (MYSQL_OPT_SSL_CA, MYSQL_OPT_SSL_CERT, MYSQL_OPT_SSL_KEY).
+ *
+ * @param handle  an options handle
+ * @param option  a MYSQL_OPT_* value that takes a string
+ * @param value   the value
+ * @return true on success, false on a bad handle or type mismatch
+ */
 native bool:mysql_options_set_str(handle, option, const value[]);
 
 // Connection
+
+/**
+ * Opens a connection pool.
+ *
+ * @param host      hostname/IP, or a path starting with / for a unix socket
+ * @param user      MySQL user
+ * @param password  MySQL password
+ * @param database  default schema
+ * @param options   an options handle, or 0 for defaults
+ * @return connection id (>= 1), or 0 on failure
+ */
 native mysql_connect(const host[], const user[], const password[], const database[], options = 0);
-// Reads host / user / password / database from a `key = value` file, keeping
-// credentials out of the gamemode source. Options stay with mysql_options_new.
+
+/**
+ * Opens a connection reading host/user/password/database from a
+ * `key = value` file, keeping credentials out of the gamemode source.
+ *
+ * @param path     path to the config file
+ * @param options  an options handle, or 0 for defaults
+ * @return connection id (>= 1), or 0 on failure
+ */
 native mysql_connect_file(const path[] = "mysql.ini", options = 0);
+
+/**
+ * Closes a connection and frees its statements and transactions.
+ *
+ * @param connId  connection id
+ * @return true on success, false if the id is unknown
+ */
 native bool:mysql_close(connId);
+
+/**
+ * Writes a short server-status line into dest.
+ *
+ * @param connId   connection id
+ * @param dest     destination buffer
+ * @param max_len  size of dest
+ * @return true on success, false on failure
+ */
 native bool:mysql_status(connId, dest[], max_len = sizeof(dest));
 
 // Error
+
+/**
+ * Last error code for a connection.
+ *
+ * @param connId  connection id, or 0 for the global error
+ * @return the MySQL error code, a MYSQL_ERROR_* value, or 0 for none
+ */
 native mysql_errno(connId = 0);
+
+/**
+ * Writes the last error message into dest.
+ *
+ * @param connId   connection id, or 0 for the global error
+ * @param dest     destination buffer
+ * @param max_len  size of dest
+ * @return true on success, false on failure
+ */
 native bool:mysql_error(connId, dest[], max_len = sizeof(dest));
 
 // Charset
+
+/**
+ * Runs SET NAMES to change the connection charset.
+ *
+ * @param connId   connection id
+ * @param charset  charset name (e.g. "utf8mb4")
+ * @return true on success, false on failure
+ */
 native bool:mysql_set_charset(connId, const charset[]);
+
+/**
+ * Reads the connection's current charset into dest.
+ *
+ * @param connId   connection id
+ * @param dest     destination buffer
+ * @param max_len  size of dest
+ * @return true on success, false on failure
+ */
 native bool:mysql_get_charset(connId, dest[], max_len = sizeof(dest));
 
 // Utility
+
+/**
+ * Number of queries submitted but not yet dispatched to a callback.
+ *
+ * @return the pending count
+ */
 native mysql_unprocessed_queries();
+
+/**
+ * Sets the minimum log level at runtime.
+ *
+ * @param log_level  a MYSQL_LOG_* value
+ * @return true
+ */
 native bool:mysql_log(log_level);
 
 // Query (non-blocking)
+
+/**
+ * Runs a query on a worker thread, FIFO-ordered.
+ *
+ * @param connId    connection id
+ * @param query     the SQL
+ * @param callback  callback to fire with the result, or "" for none
+ * @param format    types of the extra callback args ("d" int, "f" float, "s" string)
+ * @return true if submitted, false on a bad connection
+ */
 native bool:mysql_query(connId, const query[], const callback[] = "", const format[] = "", {Float,_}:...);
+
+/**
+ * Runs a query on a worker thread, parallel: no ordering guarantee.
+ *
+ * @param connId    connection id
+ * @param query     the SQL
+ * @param callback  callback to fire with the result, or "" for none
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on a bad connection
+ */
 native bool:mysql_pquery(connId, const query[], const callback[] = "", const format[] = "", {Float,_}:...);
-// Kept for backwards compatibility only: since rust-samp v3.0.0 the unified
-// on_tick already dispatches callbacks automatically on SA-MP and native open.mp.
+
+/**
+ * Drains the dispatch queue manually. You do not need to call this: since
+ * rust-samp v3.0.0 the queue is pumped automatically every tick. Kept for
+ * backwards compatibility.
+ *
+ * @return true
+ */
 native bool:mysql_tick();
-// connId selects the escaping rules, which depend on the server's sql_mode.
-// Pass the real connection whenever the server may run with NO_BACKSLASH_ESCAPES;
-// 0 assumes the MySQL default.
+
+/**
+ * Escapes a string for use inside a single-quoted SQL literal.
+ *
+ * @param src      the raw string
+ * @param dest     destination buffer
+ * @param max_len  size of dest
+ * @param connId   connection whose sql_mode picks the escaping rules; pass the
+ *                 real one when the server may run NO_BACKSLASH_ESCAPES (0 assumes
+ *                 the MySQL default)
+ * @return true on success, false on failure
+ */
 native bool:mysql_escape_string(const src[], dest[], max_len = sizeof(dest), connId = 0);
+
+/**
+ * Builds a query into dest with printf-style specifiers (%d, %f, %s escaped,
+ * %e escaped, %r raw). Truncates at the buffer boundary.
+ *
+ * @param connId   connection whose sql_mode picks the escaping rules
+ * @param dest     destination buffer
+ * @param max_len  size of dest
+ * @param format   the format string
+ * @return bytes written into dest
+ */
 native mysql_format(connId, dest[], max_len, const format[], {Float,_}:...);
-// Runs the statements of a .sql file in order on one connection, non-blocking.
-// Split on `;` outside literals and comments. NOT transactional: DDL commits
-// implicitly in MySQL. Stops at the first failure, naming which statement.
+
+/**
+ * Runs the statements of a .sql file in order on one connection, non-blocking.
+ * Split on `;` outside literals and comments. NOT transactional: DDL commits
+ * implicitly in MySQL, and on failure the statements before it stay applied.
+ *
+ * @param connId    connection id
+ * @param path      path to the .sql file
+ * @param callback  callback to fire with the last statement's result, or ""
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on a bad connection or unreadable file
+ */
 native bool:mysql_query_file(connId, const path[], const callback[] = "", const format[] = "", {Float,_}:...);
 
-// Prepared statements (non-blocking, FIFO like mysql_query)
-//
-// Values are bound server-side over the binary protocol instead of being pasted
-// into the SQL text, so no escaping is involved and a value can never be
-// reinterpreted as syntax. Prefer this over mysql_format for anything that
-// carries player input.
-//
-//   new stmt = mysql_stmt_new(connId, "SELECT id FROM users WHERE name = ? AND age > ?");
-//   mysql_stmt_bind_str(stmt, inputName);
-//   mysql_stmt_bind_int(stmt, 18);
-//   mysql_stmt_execute(stmt, "OnUsersFound", "d", playerid);
-//
-// The statement is reusable: call mysql_stmt_reset to drop the bound values and
-// bind a fresh set. mysql_stmt_execute fails if the number of bound values does
-// not match the number of ? placeholders.
+// Prepared statements (non-blocking, FIFO)
+
+/**
+ * Creates a prepared statement. Use `?` for each bound value.
+ *
+ * @param connId  connection id
+ * @param query   the SQL with `?` placeholders
+ * @return statement id (>= 1), or 0 on a bad connection
+ */
 native mysql_stmt_new(connId, const query[]);
+
+/**
+ * Frees a statement.
+ *
+ * @param stmtId  statement id
+ * @return true on success, false if the id is unknown
+ */
 native bool:mysql_stmt_close(stmtId);
+
+/**
+ * Clears the bound values, keeping the statement for reuse.
+ *
+ * @param stmtId  statement id
+ * @return true on success, false if the id is unknown
+ */
 native bool:mysql_stmt_reset(stmtId);
+
+/**
+ * Binds an integer to the next placeholder.
+ *
+ * @param stmtId  statement id
+ * @param value   the value
+ * @return true on success, false if the id is unknown or the limit is reached
+ */
 native bool:mysql_stmt_bind_int(stmtId, value);
+
+/**
+ * Binds a float to the next placeholder.
+ *
+ * @param stmtId  statement id
+ * @param value   the value
+ * @return true on success, false if the id is unknown or the limit is reached
+ */
 native bool:mysql_stmt_bind_float(stmtId, Float:value);
+
+/**
+ * Binds a string to the next placeholder.
+ *
+ * @param stmtId  statement id
+ * @param value   the value
+ * @return true on success, false if the id is unknown or the limit is reached
+ */
 native bool:mysql_stmt_bind_str(stmtId, const value[]);
+
+/**
+ * Binds SQL NULL to the next placeholder.
+ *
+ * @param stmtId  statement id
+ * @return true on success, false if the id is unknown or the limit is reached
+ */
 native bool:mysql_stmt_bind_null(stmtId);
+
+/**
+ * Executes a statement, FIFO-ordered. Fails if the number of bound values does
+ * not match the number of `?` placeholders.
+ *
+ * @param stmtId    statement id
+ * @param callback  callback to fire with the result, or "" for none
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on a bad id or arity mismatch
+ */
 native bool:mysql_stmt_execute(stmtId, const callback[] = "", const format[] = "", {Float,_}:...);
-// Parallel counterpart, mirroring mysql_pquery: no ordering guarantee.
+
+/**
+ * Executes a statement on a worker thread, parallel: no ordering guarantee.
+ *
+ * @param stmtId    statement id
+ * @param callback  callback to fire with the result, or "" for none
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on a bad id or arity mismatch
+ */
 native bool:mysql_stmt_pexecute(stmtId, const callback[] = "", const format[] = "", {Float,_}:...);
 
-// Cache
+// Cache (read inside a query callback)
+
+/**
+ * Rows in the active result set.
+ *
+ * @return the row count
+ */
 native cache_get_row_count();
+
+/**
+ * Columns in the active result set.
+ *
+ * @return the field count
+ */
 native cache_get_field_count();
+
+/**
+ * Writes a column's name into dest.
+ *
+ * @param field_idx  column index
+ * @param dest       destination buffer
+ * @param max_len    size of dest
+ * @return true on success, false if the index is out of range
+ */
 native bool:cache_get_field_name(field_idx, dest[], max_len = sizeof(dest));
+
+/**
+ * A column's MySQL type (a raw ColumnType byte).
+ *
+ * @param field_idx  column index
+ * @return the type byte, or 0 if out of range
+ */
 native cache_get_field_type(field_idx);
+
+/**
+ * Reads a cell as a string, by column index.
+ *
+ * @param row      row index
+ * @param col      column index
+ * @param dest     destination buffer
+ * @param max_len  size of dest
+ * @return true on success, false if out of range
+ */
 native bool:cache_get_value_index(row, col, dest[], max_len = sizeof(dest));
+
+/**
+ * Reads a cell as an int, by column index.
+ *
+ * @param row  row index
+ * @param col  column index
+ * @return the value, or 0 if out of range or NULL
+ */
 native cache_get_value_index_int(row, col);
+
+/**
+ * Reads a cell as a float, by column index.
+ *
+ * @param row  row index
+ * @param col  column index
+ * @return the value, or 0.0 if out of range or NULL
+ */
 native Float:cache_get_value_index_float(row, col);
+
+/**
+ * Reads a cell as a string, by column name (case-insensitive).
+ *
+ * @param row         row index
+ * @param field_name  column name
+ * @param dest        destination buffer
+ * @param max_len     size of dest
+ * @return true on success, false if the row or name is unknown
+ */
 native bool:cache_get_value_name(row, const field_name[], dest[], max_len = sizeof(dest));
+
+/**
+ * Reads a cell as an int, by column name.
+ *
+ * @param row         row index
+ * @param field_name  column name
+ * @return the value, or 0 if unknown or NULL
+ */
 native cache_get_value_name_int(row, const field_name[]);
+
+/**
+ * Reads a cell as a float, by column name.
+ *
+ * @param row         row index
+ * @param field_name  column name
+ * @return the value, or 0.0 if unknown or NULL
+ */
 native Float:cache_get_value_name_float(row, const field_name[]);
+
+/**
+ * Whether a cell is SQL NULL, by column index.
+ *
+ * @param row  row index
+ * @param col  column index
+ * @return true if NULL
+ */
 native bool:cache_is_value_index_null(row, col);
+
+/**
+ * Whether a cell is SQL NULL, by column name.
+ *
+ * @param row         row index
+ * @param field_name  column name
+ * @return true if NULL
+ */
 native bool:cache_is_value_name_null(row, const field_name[]);
+
+/**
+ * Rows affected by the last INSERT/UPDATE/DELETE.
+ *
+ * @return the affected-row count
+ */
 native cache_affected_rows();
+
+/**
+ * AUTO_INCREMENT id generated by the last INSERT.
+ *
+ * @return the insert id
+ */
 native cache_insert_id();
+
+/**
+ * Warnings the server raised for the query.
+ *
+ * @return the warning count
+ */
 native cache_warning_count();
+
+/**
+ * How long the query took to execute.
+ *
+ * @return the time in milliseconds
+ */
 native cache_get_query_exec_time();
+
+/**
+ * Writes the query text into dest.
+ *
+ * @param dest     destination buffer
+ * @param max_len  size of dest
+ * @return true on success, false on failure
+ */
 native bool:cache_get_query_string(dest[], max_len = sizeof(dest));
-// Result sets in the active cache. A plain query yields 1; a script or a
-// stored-procedure CALL can yield several. cache_set_result picks which one
-// every other cache_* native reports on (index 0 until changed).
+
+/**
+ * Result sets in the active cache. A plain query yields 1; a stored-procedure
+ * CALL or a script can yield several.
+ *
+ * @return the result-set count
+ */
 native cache_get_result_count();
+
+/**
+ * Selects which result set the other cache_* natives read (0 until changed).
+ *
+ * @param result_index  result-set index
+ * @return true on success, false if the index is out of range
+ */
 native bool:cache_set_result(result_index);
 
+/**
+ * Persists the active cache so it can be read after the callback returns.
+ *
+ * @return a saved-cache id (>= 1), or 0 on failure
+ */
 native cache_save();
+
+/**
+ * Frees a saved cache.
+ *
+ * @param cache_id  id from cache_save
+ * @return true on success, false if the id is unknown
+ */
 native bool:cache_delete(cache_id);
+
+/**
+ * Makes a saved cache the active one.
+ *
+ * @param cache_id  id from cache_save
+ * @return true on success, false if the id is unknown
+ */
 native bool:cache_set_active(cache_id);
+
+/**
+ * Clears the manually set active cache.
+ *
+ * @return true on success, false if none was set
+ */
 native bool:cache_unset_active();
+
+/**
+ * Whether any cache is currently active.
+ *
+ * @return true if one is active
+ */
 native bool:cache_is_any_active();
+
+/**
+ * Whether a saved-cache id is still valid.
+ *
+ * @param cache_id  id from cache_save
+ * @return true if valid
+ */
 native bool:cache_is_valid(cache_id);
 
-// ORM
+// ORM (bind Pawn variables to columns)
+
+/**
+ * Creates an ORM instance bound to a table.
+ *
+ * @param table   table name
+ * @param connId  connection id
+ * @return an ORM id (>= 1), or 0 on a bad connection
+ */
 native orm_create(const table[], connId);
+
+/**
+ * Destroys an ORM instance.
+ *
+ * @param orm_id  ORM id
+ * @return true on success, false if the id is unknown
+ */
 native bool:orm_destroy(orm_id);
+
+/**
+ * Last ORM error. Only the apply-cache operation sets it.
+ *
+ * @param orm_id  ORM id
+ * @return ORM_OK or ORM_NO_DATA
+ */
 native orm_errno(orm_id);
+
+/**
+ * SELECTs the row matching the key and fills the bound variables.
+ *
+ * @param orm_id    ORM id
+ * @param callback  callback to fire when done, or ""
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on failure
+ */
 native bool:orm_select(orm_id, const callback[] = "", const format[] = "", {Float,_}:...);
+
+/**
+ * UPDATEs the row matching the key with the bound variables.
+ *
+ * @param orm_id    ORM id
+ * @param callback  callback to fire when done, or ""
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on failure
+ */
 native bool:orm_update(orm_id, const callback[] = "", const format[] = "", {Float,_}:...);
+
+/**
+ * INSERTs a row from the bound variables.
+ *
+ * @param orm_id    ORM id
+ * @param callback  callback to fire when done, or ""
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on failure
+ */
 native bool:orm_insert(orm_id, const callback[] = "", const format[] = "", {Float,_}:...);
+
+/**
+ * DELETEs the row matching the key.
+ *
+ * @param orm_id    ORM id
+ * @param callback  callback to fire when done, or ""
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on failure
+ */
 native bool:orm_delete(orm_id, const callback[] = "", const format[] = "", {Float,_}:...);
+
+/**
+ * INSERTs when the key is empty, UPDATEs otherwise.
+ *
+ * @param orm_id    ORM id
+ * @param callback  callback to fire when done, or ""
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on failure
+ */
 native bool:orm_save(orm_id, const callback[] = "", const format[] = "", {Float,_}:...);
+
+/**
+ * Copies a row from the active cache into the bound variables.
+ *
+ * @param orm_id  ORM id
+ * @param row     row index in the active cache
+ * @return true on success, false if there is no such row
+ */
 native bool:orm_apply_cache(orm_id, row = 0);
+
+/**
+ * Binds an int variable to a column.
+ *
+ * @param orm_id       ORM id
+ * @param var          the variable (read on write, written on load)
+ * @param column_name  column name
+ * @return true on success, false if the id is unknown
+ */
 native bool:orm_addvar_int(orm_id, &var, const column_name[]);
+
+/**
+ * Binds a float variable to a column.
+ *
+ * @param orm_id       ORM id
+ * @param var          the variable
+ * @param column_name  column name
+ * @return true on success, false if the id is unknown
+ */
 native bool:orm_addvar_float(orm_id, &Float:var, const column_name[]);
+
+/**
+ * Binds a string variable to a column.
+ *
+ * @param orm_id       ORM id
+ * @param var          the buffer
+ * @param var_max_len  size of the buffer (capped at 4096)
+ * @param column_name  column name
+ * @return true on success, false on a bad id or length
+ */
 native bool:orm_addvar_string(orm_id, var[], var_max_len, const column_name[]);
+
+/**
+ * Unbinds a column.
+ *
+ * @param orm_id       ORM id
+ * @param column_name  column name
+ * @return true if a binding was removed
+ */
 native bool:orm_delvar(orm_id, const column_name[]);
+
+/**
+ * Removes all bindings.
+ *
+ * @param orm_id  ORM id
+ * @return true on success, false if the id is unknown
+ */
 native bool:orm_clear_vars(orm_id);
+
+/**
+ * Sets which bound column is the key for select/update/delete/save.
+ *
+ * @param orm_id       ORM id
+ * @param column_name  column name
+ * @return true on success, false if the id is unknown
+ */
 native bool:orm_setkey(orm_id, const column_name[]);
 
 // Password hashing (Argon2id)
-//
-// Both natives run on a worker thread - Argon2id is deliberately slow, so
-// hashing on the server thread would stall it. The result is delivered as the
-// FIRST argument of the callback, followed by the extras described by format.
-//
-//   forward OnHashed(const hash[], playerid);
-//   mysql_hash_password("secret", "OnHashed", "d", playerid);
-//
-//   forward OnChecked(bool:success, playerid);
-//   mysql_verify_password("secret", stored_hash, "OnChecked", "d", playerid);
-//
-// The hash is a PHC string (`$argon2id$v=19$m=...`) around 100 characters long;
-// size the storage column and any Pawn buffer accordingly (VARCHAR(255) is the
-// usual choice). It already embeds its own random salt - do not add one.
+
+/**
+ * Hashes a password with Argon2id, off the server thread.
+ *
+ * @param password  the plaintext
+ * @param callback  callback receiving the PHC hash as its first argument
+ * @param format    types of the extra callback args
+ * @return true if queued, false if the callback is empty, the password exceeds
+ *         1 KiB, or the work queue is full
+ */
 native bool:mysql_hash_password(const password[], const callback[], const format[] = "", {Float,_}:...);
+
+/**
+ * Verifies a password against a stored PHC hash, off the server thread.
+ *
+ * @param password  the plaintext
+ * @param hash      the stored PHC string
+ * @param callback  callback receiving the bool result as its first argument
+ * @param format    types of the extra callback args
+ * @return true if queued, false if the callback is empty, the password exceeds
+ *         1 KiB, or the work queue is full
+ */
 native bool:mysql_verify_password(const password[], const hash[], const callback[], const format[] = "", {Float,_}:...);
 
 // Transactions (non-blocking, all-or-nothing)
-//
-// Steps are collected first and then executed as one unit on a single
-// connection: START TRANSACTION, every step, COMMIT. Any failing step rolls the
-// whole batch back and fires OnQueryError. There is no interactive
-// begin/commit API on purpose - holding a pooled connection between ticks would
-// leak it whenever a gamemode never reached the commit.
-//
-//   new tx = mysql_transaction_new(connId);
-//   mysql_transaction_add(tx, "UPDATE accounts SET balance = balance - 100 WHERE id = 1");
-//   mysql_transaction_add(tx, "UPDATE accounts SET balance = balance + 100 WHERE id = 2");
-//   mysql_transaction_execute(tx, "OnTransferDone", "d", playerid);
-//
-// mysql_transaction_add_stmt appends a prepared statement with its bound values,
-// which is the safe way to put player input inside a transaction.
-// mysql_transaction_execute consumes the handle: the ID is invalid afterwards.
-// The callback receives the cache of the LAST step.
+
+/**
+ * Creates a transaction.
+ *
+ * @param connId  connection id
+ * @return a transaction id (>= 1), or 0 on a bad connection
+ */
 native mysql_transaction_new(connId);
+
+/**
+ * Discards a transaction that was never executed.
+ *
+ * @param txId  transaction id
+ * @return true on success, false if the id is unknown
+ */
 native bool:mysql_transaction_destroy(txId);
+
+/**
+ * Appends a plain SQL step.
+ *
+ * @param txId   transaction id
+ * @param query  the SQL
+ * @return true on success, false if the id is unknown
+ */
 native bool:mysql_transaction_add(txId, const query[]);
+
+/**
+ * Appends a prepared statement with its bound values - the safe way to put
+ * player input in a transaction. The statement itself is untouched.
+ *
+ * @param txId    transaction id
+ * @param stmtId  statement id
+ * @return true on success, false on a bad id or arity mismatch
+ */
 native bool:mysql_transaction_add_stmt(txId, stmtId);
+
+/**
+ * Runs every step atomically, then destroys the transaction (the id is invalid
+ * afterwards). The callback receives the cache of the LAST step.
+ *
+ * @param txId      transaction id
+ * @param callback  callback to fire on commit, or ""
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on a bad id or empty batch
+ */
 native bool:mysql_transaction_execute(txId, const callback[] = "", const format[] = "", {Float,_}:...);

--- a/include/mysql_samp_omp.inc
+++ b/include/mysql_samp_omp.inc
@@ -16,7 +16,7 @@
 #define _mysql_samp_omp_included
 
 
-#define MYSQL_SAMP_VERSION "1.2.0"
+#define MYSQL_SAMP_VERSION "1.3.0"
 
 // Connection options
 enum {

--- a/include/mysql_samp_omp.inc
+++ b/include/mysql_samp_omp.inc
@@ -65,161 +65,720 @@ enum {
     ORM_NO_DATA,
 }
 
-// Forward: invoked when a threaded query fails.
+/**
+ * Fired on every loaded script when a threaded query fails.
+ *
+ * @param errorid   MySQL error code (1062, 1045, ...), or 0 for transport errors
+ * @param error     server error message
+ * @param callback  the callback the query asked for, or "" if none
+ * @param query     the SQL that failed
+ * @param connId    connection that produced the error
+ */
 forward OnQueryError(errorid, const error[], const callback[], const query[], connId);
 
 // Options
+
+/**
+ * Creates an options handle for a connection.
+ *
+ * @return the options handle (>= 1), or 0 on failure
+ */
 native MySQL_OptionsNew() = mysql_options_new;
+
+/**
+ * Sets an integer option (MYSQL_OPT_PORT, MYSQL_OPT_SSL, ...).
+ *
+ * @param handle  an options handle
+ * @param option  a MYSQL_OPT_* value that takes an int
+ * @param value   the value
+ * @return true on success, false on a bad handle or type mismatch
+ */
 native bool:MySQL_OptionsSetInt(handle, option, value) = mysql_options_set_int;
+
+/**
+ * Sets a string option (MYSQL_OPT_SSL_CA, MYSQL_OPT_SSL_CERT, MYSQL_OPT_SSL_KEY).
+ *
+ * @param handle  an options handle
+ * @param option  a MYSQL_OPT_* value that takes a string
+ * @param value   the value
+ * @return true on success, false on a bad handle or type mismatch
+ */
 native bool:MySQL_OptionsSetStr(handle, option, const value[]) = mysql_options_set_str;
 
 // Connection
+
+/**
+ * Opens a connection pool.
+ *
+ * @param host      hostname/IP, or a path starting with / for a unix socket
+ * @param user      MySQL user
+ * @param password  MySQL password
+ * @param database  default schema
+ * @param options   an options handle, or 0 for defaults
+ * @return connection id (>= 1), or 0 on failure
+ */
 native MySQL_Connect(const host[], const user[], const password[], const database[], options = 0) = mysql_connect;
-// Reads host / user / password / database from a `key = value` file, keeping
-// credentials out of the gamemode source. Options stay with mysql_options_new.
+
+/**
+ * Opens a connection reading host/user/password/database from a
+ * `key = value` file, keeping credentials out of the gamemode source.
+ *
+ * @param path     path to the config file
+ * @param options  an options handle, or 0 for defaults
+ * @return connection id (>= 1), or 0 on failure
+ */
 native MySQL_ConnectFile(const path[] = "mysql.ini", options = 0) = mysql_connect_file;
+
+/**
+ * Closes a connection and frees its statements and transactions.
+ *
+ * @param connId  connection id
+ * @return true on success, false if the id is unknown
+ */
 native bool:MySQL_Close(connId) = mysql_close;
+
+/**
+ * Writes a short server-status line into dest.
+ *
+ * @param connId   connection id
+ * @param dest     destination buffer
+ * @param max_len  size of dest
+ * @return true on success, false on failure
+ */
 native bool:MySQL_Status(connId, dest[], max_len = sizeof(dest)) = mysql_status;
 
 // Error
+
+/**
+ * Last error code for a connection.
+ *
+ * @param connId  connection id, or 0 for the global error
+ * @return the MySQL error code, a MYSQL_ERROR_* value, or 0 for none
+ */
 native MySQL_Errno(connId = 0) = mysql_errno;
+
+/**
+ * Writes the last error message into dest.
+ *
+ * @param connId   connection id, or 0 for the global error
+ * @param dest     destination buffer
+ * @param max_len  size of dest
+ * @return true on success, false on failure
+ */
 native bool:MySQL_Error(connId, dest[], max_len = sizeof(dest)) = mysql_error;
 
 // Charset
+
+/**
+ * Runs SET NAMES to change the connection charset.
+ *
+ * @param connId   connection id
+ * @param charset  charset name (e.g. "utf8mb4")
+ * @return true on success, false on failure
+ */
 native bool:MySQL_SetCharset(connId, const charset[]) = mysql_set_charset;
+
+/**
+ * Reads the connection's current charset into dest.
+ *
+ * @param connId   connection id
+ * @param dest     destination buffer
+ * @param max_len  size of dest
+ * @return true on success, false on failure
+ */
 native bool:MySQL_GetCharset(connId, dest[], max_len = sizeof(dest)) = mysql_get_charset;
 
 // Utility
+
+/**
+ * Number of queries submitted but not yet dispatched to a callback.
+ *
+ * @return the pending count
+ */
 native MySQL_UnprocessedQueries() = mysql_unprocessed_queries;
+
+/**
+ * Sets the minimum log level at runtime.
+ *
+ * @param log_level  a MYSQL_LOG_* value
+ * @return true
+ */
 native bool:MySQL_Log(log_level) = mysql_log;
 
 // Query (non-blocking)
+
+/**
+ * Runs a query on a worker thread, FIFO-ordered.
+ *
+ * @param connId    connection id
+ * @param query     the SQL
+ * @param callback  callback to fire with the result, or "" for none
+ * @param format    types of the extra callback args ("d" int, "f" float, "s" string)
+ * @return true if submitted, false on a bad connection
+ */
 native bool:MySQL_Query(connId, const query[], const callback[] = "", const format[] = "", {Float,_}:...) = mysql_query;
+
+/**
+ * Runs a query on a worker thread, parallel: no ordering guarantee.
+ *
+ * @param connId    connection id
+ * @param query     the SQL
+ * @param callback  callback to fire with the result, or "" for none
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on a bad connection
+ */
 native bool:MySQL_PQuery(connId, const query[], const callback[] = "", const format[] = "", {Float,_}:...) = mysql_pquery;
-// Kept for backwards compatibility only: since rust-samp v3.0.0 the unified
-// on_tick already dispatches callbacks automatically on SA-MP and native open.mp.
+
+/**
+ * Drains the dispatch queue manually. You do not need to call this: since
+ * rust-samp v3.0.0 the queue is pumped automatically every tick. Kept for
+ * backwards compatibility.
+ *
+ * @return true
+ */
 native bool:MySQL_Tick() = mysql_tick;
-// connId selects the escaping rules, which depend on the server's sql_mode.
-// Pass the real connection whenever the server may run with NO_BACKSLASH_ESCAPES;
-// 0 assumes the MySQL default.
+
+/**
+ * Escapes a string for use inside a single-quoted SQL literal.
+ *
+ * @param src      the raw string
+ * @param dest     destination buffer
+ * @param max_len  size of dest
+ * @param connId   connection whose sql_mode picks the escaping rules; pass the
+ *                 real one when the server may run NO_BACKSLASH_ESCAPES (0 assumes
+ *                 the MySQL default)
+ * @return true on success, false on failure
+ */
 native bool:MySQL_EscapeString(const src[], dest[], max_len = sizeof(dest), connId = 0) = mysql_escape_string;
+
+/**
+ * Builds a query into dest with printf-style specifiers (%d, %f, %s escaped,
+ * %e escaped, %r raw). Truncates at the buffer boundary.
+ *
+ * @param connId   connection whose sql_mode picks the escaping rules
+ * @param dest     destination buffer
+ * @param max_len  size of dest
+ * @param format   the format string
+ * @return bytes written into dest
+ */
 native MySQL_Format(connId, dest[], max_len, const format[], {Float,_}:...) = mysql_format;
-// Runs the statements of a .sql file in order on one connection, non-blocking.
-// Split on `;` outside literals and comments. NOT transactional: DDL commits
-// implicitly in MySQL. Stops at the first failure, naming which statement.
+
+/**
+ * Runs the statements of a .sql file in order on one connection, non-blocking.
+ * Split on `;` outside literals and comments. NOT transactional: DDL commits
+ * implicitly in MySQL, and on failure the statements before it stay applied.
+ *
+ * @param connId    connection id
+ * @param path      path to the .sql file
+ * @param callback  callback to fire with the last statement's result, or ""
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on a bad connection or unreadable file
+ */
 native bool:MySQL_QueryFile(connId, const path[], const callback[] = "", const format[] = "", {Float,_}:...) = mysql_query_file;
 
-// Prepared statements (non-blocking, FIFO like mysql_query)
-//
-// Values are bound server-side over the binary protocol instead of being pasted
-// into the SQL text, so no escaping is involved and a value can never be
-// reinterpreted as syntax. Prefer this over mysql_format for anything that
-// carries player input.
-//
-//   new stmt = mysql_stmt_new(connId, "SELECT id FROM users WHERE name = ? AND age > ?");
-//   mysql_stmt_bind_str(stmt, inputName);
-//   mysql_stmt_bind_int(stmt, 18);
-//   mysql_stmt_execute(stmt, "OnUsersFound", "d", playerid);
-//
-// The statement is reusable: call mysql_stmt_reset to drop the bound values and
-// bind a fresh set. mysql_stmt_execute fails if the number of bound values does
-// not match the number of ? placeholders.
+// Prepared statements (non-blocking, FIFO)
+
+/**
+ * Creates a prepared statement. Use `?` for each bound value.
+ *
+ * @param connId  connection id
+ * @param query   the SQL with `?` placeholders
+ * @return statement id (>= 1), or 0 on a bad connection
+ */
 native MySQL_StmtNew(connId, const query[]) = mysql_stmt_new;
+
+/**
+ * Frees a statement.
+ *
+ * @param stmtId  statement id
+ * @return true on success, false if the id is unknown
+ */
 native bool:MySQL_StmtClose(stmtId) = mysql_stmt_close;
+
+/**
+ * Clears the bound values, keeping the statement for reuse.
+ *
+ * @param stmtId  statement id
+ * @return true on success, false if the id is unknown
+ */
 native bool:MySQL_StmtReset(stmtId) = mysql_stmt_reset;
+
+/**
+ * Binds an integer to the next placeholder.
+ *
+ * @param stmtId  statement id
+ * @param value   the value
+ * @return true on success, false if the id is unknown or the limit is reached
+ */
 native bool:MySQL_StmtBindInt(stmtId, value) = mysql_stmt_bind_int;
+
+/**
+ * Binds a float to the next placeholder.
+ *
+ * @param stmtId  statement id
+ * @param value   the value
+ * @return true on success, false if the id is unknown or the limit is reached
+ */
 native bool:MySQL_StmtBindFloat(stmtId, Float:value) = mysql_stmt_bind_float;
+
+/**
+ * Binds a string to the next placeholder.
+ *
+ * @param stmtId  statement id
+ * @param value   the value
+ * @return true on success, false if the id is unknown or the limit is reached
+ */
 native bool:MySQL_StmtBindStr(stmtId, const value[]) = mysql_stmt_bind_str;
+
+/**
+ * Binds SQL NULL to the next placeholder.
+ *
+ * @param stmtId  statement id
+ * @return true on success, false if the id is unknown or the limit is reached
+ */
 native bool:MySQL_StmtBindNull(stmtId) = mysql_stmt_bind_null;
+
+/**
+ * Executes a statement, FIFO-ordered. Fails if the number of bound values does
+ * not match the number of `?` placeholders.
+ *
+ * @param stmtId    statement id
+ * @param callback  callback to fire with the result, or "" for none
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on a bad id or arity mismatch
+ */
 native bool:MySQL_StmtExecute(stmtId, const callback[] = "", const format[] = "", {Float,_}:...) = mysql_stmt_execute;
-// Parallel counterpart, mirroring mysql_pquery: no ordering guarantee.
+
+/**
+ * Executes a statement on a worker thread, parallel: no ordering guarantee.
+ *
+ * @param stmtId    statement id
+ * @param callback  callback to fire with the result, or "" for none
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on a bad id or arity mismatch
+ */
 native bool:MySQL_StmtPExecute(stmtId, const callback[] = "", const format[] = "", {Float,_}:...) = mysql_stmt_pexecute;
 
-// Cache
+// Cache (read inside a query callback)
+
+/**
+ * Rows in the active result set.
+ *
+ * @return the row count
+ */
 native Cache_GetRowCount() = cache_get_row_count;
+
+/**
+ * Columns in the active result set.
+ *
+ * @return the field count
+ */
 native Cache_GetFieldCount() = cache_get_field_count;
+
+/**
+ * Writes a column's name into dest.
+ *
+ * @param field_idx  column index
+ * @param dest       destination buffer
+ * @param max_len    size of dest
+ * @return true on success, false if the index is out of range
+ */
 native bool:Cache_GetFieldName(field_idx, dest[], max_len = sizeof(dest)) = cache_get_field_name;
+
+/**
+ * A column's MySQL type (a raw ColumnType byte).
+ *
+ * @param field_idx  column index
+ * @return the type byte, or 0 if out of range
+ */
 native Cache_GetFieldType(field_idx) = cache_get_field_type;
+
+/**
+ * Reads a cell as a string, by column index.
+ *
+ * @param row      row index
+ * @param col      column index
+ * @param dest     destination buffer
+ * @param max_len  size of dest
+ * @return true on success, false if out of range
+ */
 native bool:Cache_GetValueIndex(row, col, dest[], max_len = sizeof(dest)) = cache_get_value_index;
+
+/**
+ * Reads a cell as an int, by column index.
+ *
+ * @param row  row index
+ * @param col  column index
+ * @return the value, or 0 if out of range or NULL
+ */
 native Cache_GetValueIndexInt(row, col) = cache_get_value_index_int;
+
+/**
+ * Reads a cell as a float, by column index.
+ *
+ * @param row  row index
+ * @param col  column index
+ * @return the value, or 0.0 if out of range or NULL
+ */
 native Float:Cache_GetValueIndexFloat(row, col) = cache_get_value_index_float;
+
+/**
+ * Reads a cell as a string, by column name (case-insensitive).
+ *
+ * @param row         row index
+ * @param field_name  column name
+ * @param dest        destination buffer
+ * @param max_len     size of dest
+ * @return true on success, false if the row or name is unknown
+ */
 native bool:Cache_GetValueName(row, const field_name[], dest[], max_len = sizeof(dest)) = cache_get_value_name;
+
+/**
+ * Reads a cell as an int, by column name.
+ *
+ * @param row         row index
+ * @param field_name  column name
+ * @return the value, or 0 if unknown or NULL
+ */
 native Cache_GetValueNameInt(row, const field_name[]) = cache_get_value_name_int;
+
+/**
+ * Reads a cell as a float, by column name.
+ *
+ * @param row         row index
+ * @param field_name  column name
+ * @return the value, or 0.0 if unknown or NULL
+ */
 native Float:Cache_GetValueNameFloat(row, const field_name[]) = cache_get_value_name_float;
+
+/**
+ * Whether a cell is SQL NULL, by column index.
+ *
+ * @param row  row index
+ * @param col  column index
+ * @return true if NULL
+ */
 native bool:Cache_IsValueIndexNull(row, col) = cache_is_value_index_null;
+
+/**
+ * Whether a cell is SQL NULL, by column name.
+ *
+ * @param row         row index
+ * @param field_name  column name
+ * @return true if NULL
+ */
 native bool:Cache_IsValueNameNull(row, const field_name[]) = cache_is_value_name_null;
+
+/**
+ * Rows affected by the last INSERT/UPDATE/DELETE.
+ *
+ * @return the affected-row count
+ */
 native Cache_AffectedRows() = cache_affected_rows;
+
+/**
+ * AUTO_INCREMENT id generated by the last INSERT.
+ *
+ * @return the insert id
+ */
 native Cache_InsertId() = cache_insert_id;
+
+/**
+ * Warnings the server raised for the query.
+ *
+ * @return the warning count
+ */
 native Cache_WarningCount() = cache_warning_count;
+
+/**
+ * How long the query took to execute.
+ *
+ * @return the time in milliseconds
+ */
 native Cache_GetQueryExecTime() = cache_get_query_exec_time;
+
+/**
+ * Writes the query text into dest.
+ *
+ * @param dest     destination buffer
+ * @param max_len  size of dest
+ * @return true on success, false on failure
+ */
 native bool:Cache_GetQueryString(dest[], max_len = sizeof(dest)) = cache_get_query_string;
-// Result sets in the active cache. A plain query yields 1; a script or a
-// stored-procedure CALL can yield several. cache_set_result picks which one
-// every other cache_* native reports on (index 0 until changed).
+
+/**
+ * Result sets in the active cache. A plain query yields 1; a stored-procedure
+ * CALL or a script can yield several.
+ *
+ * @return the result-set count
+ */
 native Cache_GetResultCount() = cache_get_result_count;
+
+/**
+ * Selects which result set the other cache_* natives read (0 until changed).
+ *
+ * @param result_index  result-set index
+ * @return true on success, false if the index is out of range
+ */
 native bool:Cache_SetResult(result_index) = cache_set_result;
 
+/**
+ * Persists the active cache so it can be read after the callback returns.
+ *
+ * @return a saved-cache id (>= 1), or 0 on failure
+ */
 native Cache_Save() = cache_save;
+
+/**
+ * Frees a saved cache.
+ *
+ * @param cache_id  id from cache_save
+ * @return true on success, false if the id is unknown
+ */
 native bool:Cache_Delete(cache_id) = cache_delete;
+
+/**
+ * Makes a saved cache the active one.
+ *
+ * @param cache_id  id from cache_save
+ * @return true on success, false if the id is unknown
+ */
 native bool:Cache_SetActive(cache_id) = cache_set_active;
+
+/**
+ * Clears the manually set active cache.
+ *
+ * @return true on success, false if none was set
+ */
 native bool:Cache_UnsetActive() = cache_unset_active;
+
+/**
+ * Whether any cache is currently active.
+ *
+ * @return true if one is active
+ */
 native bool:Cache_IsAnyActive() = cache_is_any_active;
+
+/**
+ * Whether a saved-cache id is still valid.
+ *
+ * @param cache_id  id from cache_save
+ * @return true if valid
+ */
 native bool:Cache_IsValid(cache_id) = cache_is_valid;
 
-// ORM
+// ORM (bind Pawn variables to columns)
+
+/**
+ * Creates an ORM instance bound to a table.
+ *
+ * @param table   table name
+ * @param connId  connection id
+ * @return an ORM id (>= 1), or 0 on a bad connection
+ */
 native ORM_Create(const table[], connId) = orm_create;
+
+/**
+ * Destroys an ORM instance.
+ *
+ * @param orm_id  ORM id
+ * @return true on success, false if the id is unknown
+ */
 native bool:ORM_Destroy(orm_id) = orm_destroy;
+
+/**
+ * Last ORM error. Only the apply-cache operation sets it.
+ *
+ * @param orm_id  ORM id
+ * @return ORM_OK or ORM_NO_DATA
+ */
 native ORM_Errno(orm_id) = orm_errno;
+
+/**
+ * SELECTs the row matching the key and fills the bound variables.
+ *
+ * @param orm_id    ORM id
+ * @param callback  callback to fire when done, or ""
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on failure
+ */
 native bool:ORM_Select(orm_id, const callback[] = "", const format[] = "", {Float,_}:...) = orm_select;
+
+/**
+ * UPDATEs the row matching the key with the bound variables.
+ *
+ * @param orm_id    ORM id
+ * @param callback  callback to fire when done, or ""
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on failure
+ */
 native bool:ORM_Update(orm_id, const callback[] = "", const format[] = "", {Float,_}:...) = orm_update;
+
+/**
+ * INSERTs a row from the bound variables.
+ *
+ * @param orm_id    ORM id
+ * @param callback  callback to fire when done, or ""
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on failure
+ */
 native bool:ORM_Insert(orm_id, const callback[] = "", const format[] = "", {Float,_}:...) = orm_insert;
+
+/**
+ * DELETEs the row matching the key.
+ *
+ * @param orm_id    ORM id
+ * @param callback  callback to fire when done, or ""
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on failure
+ */
 native bool:ORM_Delete(orm_id, const callback[] = "", const format[] = "", {Float,_}:...) = orm_delete;
+
+/**
+ * INSERTs when the key is empty, UPDATEs otherwise.
+ *
+ * @param orm_id    ORM id
+ * @param callback  callback to fire when done, or ""
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on failure
+ */
 native bool:ORM_Save(orm_id, const callback[] = "", const format[] = "", {Float,_}:...) = orm_save;
+
+/**
+ * Copies a row from the active cache into the bound variables.
+ *
+ * @param orm_id  ORM id
+ * @param row     row index in the active cache
+ * @return true on success, false if there is no such row
+ */
 native bool:ORM_ApplyCache(orm_id, row = 0) = orm_apply_cache;
+
+/**
+ * Binds an int variable to a column.
+ *
+ * @param orm_id       ORM id
+ * @param var          the variable (read on write, written on load)
+ * @param column_name  column name
+ * @return true on success, false if the id is unknown
+ */
 native bool:ORM_AddVarInt(orm_id, &var, const column_name[]) = orm_addvar_int;
+
+/**
+ * Binds a float variable to a column.
+ *
+ * @param orm_id       ORM id
+ * @param var          the variable
+ * @param column_name  column name
+ * @return true on success, false if the id is unknown
+ */
 native bool:ORM_AddVarFloat(orm_id, &Float:var, const column_name[]) = orm_addvar_float;
+
+/**
+ * Binds a string variable to a column.
+ *
+ * @param orm_id       ORM id
+ * @param var          the buffer
+ * @param var_max_len  size of the buffer (capped at 4096)
+ * @param column_name  column name
+ * @return true on success, false on a bad id or length
+ */
 native bool:ORM_AddVarString(orm_id, var[], var_max_len, const column_name[]) = orm_addvar_string;
+
+/**
+ * Unbinds a column.
+ *
+ * @param orm_id       ORM id
+ * @param column_name  column name
+ * @return true if a binding was removed
+ */
 native bool:ORM_DelVar(orm_id, const column_name[]) = orm_delvar;
+
+/**
+ * Removes all bindings.
+ *
+ * @param orm_id  ORM id
+ * @return true on success, false if the id is unknown
+ */
 native bool:ORM_ClearVars(orm_id) = orm_clear_vars;
+
+/**
+ * Sets which bound column is the key for select/update/delete/save.
+ *
+ * @param orm_id       ORM id
+ * @param column_name  column name
+ * @return true on success, false if the id is unknown
+ */
 native bool:ORM_SetKey(orm_id, const column_name[]) = orm_setkey;
 
 // Password hashing (Argon2id)
-//
-// Both natives run on a worker thread - Argon2id is deliberately slow, so
-// hashing on the server thread would stall it. The result is delivered as the
-// FIRST argument of the callback, followed by the extras described by format.
-//
-//   forward OnHashed(const hash[], playerid);
-//   mysql_hash_password("secret", "OnHashed", "d", playerid);
-//
-//   forward OnChecked(bool:success, playerid);
-//   mysql_verify_password("secret", stored_hash, "OnChecked", "d", playerid);
-//
-// The hash is a PHC string (`$argon2id$v=19$m=...`) around 100 characters long;
-// size the storage column and any Pawn buffer accordingly (VARCHAR(255) is the
-// usual choice). It already embeds its own random salt - do not add one.
+
+/**
+ * Hashes a password with Argon2id, off the server thread.
+ *
+ * @param password  the plaintext
+ * @param callback  callback receiving the PHC hash as its first argument
+ * @param format    types of the extra callback args
+ * @return true if queued, false if the callback is empty, the password exceeds
+ *         1 KiB, or the work queue is full
+ */
 native bool:MySQL_HashPassword(const password[], const callback[], const format[] = "", {Float,_}:...) = mysql_hash_password;
+
+/**
+ * Verifies a password against a stored PHC hash, off the server thread.
+ *
+ * @param password  the plaintext
+ * @param hash      the stored PHC string
+ * @param callback  callback receiving the bool result as its first argument
+ * @param format    types of the extra callback args
+ * @return true if queued, false if the callback is empty, the password exceeds
+ *         1 KiB, or the work queue is full
+ */
 native bool:MySQL_VerifyPassword(const password[], const hash[], const callback[], const format[] = "", {Float,_}:...) = mysql_verify_password;
 
 // Transactions (non-blocking, all-or-nothing)
-//
-// Steps are collected first and then executed as one unit on a single
-// connection: START TRANSACTION, every step, COMMIT. Any failing step rolls the
-// whole batch back and fires OnQueryError. There is no interactive
-// begin/commit API on purpose - holding a pooled connection between ticks would
-// leak it whenever a gamemode never reached the commit.
-//
-//   new tx = mysql_transaction_new(connId);
-//   mysql_transaction_add(tx, "UPDATE accounts SET balance = balance - 100 WHERE id = 1");
-//   mysql_transaction_add(tx, "UPDATE accounts SET balance = balance + 100 WHERE id = 2");
-//   mysql_transaction_execute(tx, "OnTransferDone", "d", playerid);
-//
-// mysql_transaction_add_stmt appends a prepared statement with its bound values,
-// which is the safe way to put player input inside a transaction.
-// mysql_transaction_execute consumes the handle: the ID is invalid afterwards.
-// The callback receives the cache of the LAST step.
+
+/**
+ * Creates a transaction.
+ *
+ * @param connId  connection id
+ * @return a transaction id (>= 1), or 0 on a bad connection
+ */
 native MySQL_TransactionNew(connId) = mysql_transaction_new;
+
+/**
+ * Discards a transaction that was never executed.
+ *
+ * @param txId  transaction id
+ * @return true on success, false if the id is unknown
+ */
 native bool:MySQL_TransactionDestroy(txId) = mysql_transaction_destroy;
+
+/**
+ * Appends a plain SQL step.
+ *
+ * @param txId   transaction id
+ * @param query  the SQL
+ * @return true on success, false if the id is unknown
+ */
 native bool:MySQL_TransactionAdd(txId, const query[]) = mysql_transaction_add;
+
+/**
+ * Appends a prepared statement with its bound values - the safe way to put
+ * player input in a transaction. The statement itself is untouched.
+ *
+ * @param txId    transaction id
+ * @param stmtId  statement id
+ * @return true on success, false on a bad id or arity mismatch
+ */
 native bool:MySQL_TransactionAddStmt(txId, stmtId) = mysql_transaction_add_stmt;
+
+/**
+ * Runs every step atomically, then destroys the transaction (the id is invalid
+ * afterwards). The callback receives the cache of the LAST step.
+ *
+ * @param txId      transaction id
+ * @param callback  callback to fire on commit, or ""
+ * @param format    types of the extra callback args
+ * @return true if submitted, false on a bad id or empty batch
+ */
 native bool:MySQL_TransactionExecute(txId, const callback[] = "", const format[] = "", {Float,_}:...) = mysql_transaction_execute;

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -55,9 +55,7 @@ pub fn invoke_callback(amx_list: &[AmxIdent], info: &CallbackInfo) {
                         // `info` flows from a manager that may have handled a
                         // password, and CodeQL cannot tell name from secret, so
                         // keeping the message constant closes that path.
-                        Logger::error(
-                            "Failed to allocate an AMX string for a callback argument.",
-                        );
+                        Logger::error("Failed to allocate an AMX string for a callback argument.");
                         break;
                     }
                 },

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -51,10 +51,13 @@ pub fn invoke_callback(amx_list: &[AmxIdent], info: &CallbackInfo) {
                     }
                     Err(_) => {
                         push_ok = false;
-                        Logger::error(&format!(
-                            "Failed to allocate string for callback '{}'.",
-                            info.name
-                        ));
+                        // The callback name is deliberately not interpolated:
+                        // `info` flows from a manager that may have handled a
+                        // password, and CodeQL cannot tell name from secret, so
+                        // keeping the message constant closes that path.
+                        Logger::error(
+                            "Failed to allocate an AMX string for a callback argument.",
+                        );
                         break;
                     }
                 },
@@ -65,10 +68,7 @@ pub fn invoke_callback(amx_list: &[AmxIdent], info: &CallbackInfo) {
         if push_ok {
             let _ = amx.exec(idx);
         } else {
-            Logger::error(&format!(
-                "Callback '{}' aborted: failed to push parameters to AMX stack.",
-                info.name
-            ));
+            Logger::error("A callback was aborted: failed to push parameters to the AMX stack.");
         }
         break; // Only invoke in the first AMX that has the public
     }


### PR DESCRIPTION
Release **v1.3.0**. Additive: no Pawn native removed or renamed, so 1.2.0 gamemodes compile unchanged.

## What's in this PR

- **JavaDoc on every native and on `OnQueryError`** — `/** */` blocks with `@param`/`@return`, the style PawnPro surfaces on hover/autocomplete. One line of description, one `@param` per argument, one `@return`. Flows into both includes from the same source; both stay ASCII.
- **Closes the `rust/cleartext-logging` CodeQL alerts (false positives) in code.** The #33 enum fix removed one taint path; reading the SARIF showed a second — `poll_results()` → the callback `info` → `invoke_callback` → a `Logger::error` interpolating `info.name` (the callback name, e.g. `"OnHashed"`, not the password, but CodeQL cannot tell a struct field from the secret). Those two infra error logs no longer interpolate the name. **Verified on this PR's merge-ref: 0 `rust/cleartext-logging` alerts remain** (was 5).
- **`build.rs` declares its real inputs** (`cargo:rerun-if-changed`). Editing a generated `.inc`, an example, or a doc no longer re-runs the build script or invalidates the Rust test cache. Verified: touching a generated `.inc` leaves everything `Fresh`; touching the template re-runs.
- **Version bump 1.2.0 → 1.3.0** and a CHANGELOG section consolidating everything since 1.2.0 (the styled include #34, the ASCII cleanup #35, the `proc-macro-error2` drop #20, the CI/tooling bumps, and the two known informational advisories that are pinned behind the `mysql` crate).

## Verification

- 171 tests, clippy clean, both targets build (`i686-unknown-linux-gnu`, `i686-pc-windows-msvc`).
- All CI checks green, including CodeQL and Rustfmt.
- Release notes: the `release.yml` `awk` extraction picks up the `## [1.3.0]` section correctly.

## After merge

Tag `v1.3.0` (dated 2026/09/07 in the CHANGELOG) to trigger `release.yml`. The workflow validates the tag against `Cargo.toml`, which is already at 1.3.0.
